### PR TITLE
Implement ucl_array_replace_index()

### DIFF
--- a/include/ucl.h
+++ b/include/ucl.h
@@ -466,9 +466,9 @@ UCL_EXTERN const ucl_object_t* ucl_array_find_index (const ucl_object_t *top,
  * @param top destination object (must be of type UCL_ARRAY)
  * @param elt element to append (must NOT be NULL)
  * @param index array index in destination to overwrite with elt
- * @return true if array index has been replaced
+ * @return object that was replaced or NULL if index is not found
  */
-bool
+ucl_object_t *
 ucl_array_replace_index (ucl_object_t *top, ucl_object_t *elt,
 	unsigned int index);
 

--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -1924,22 +1924,26 @@ ucl_array_find_index (const ucl_object_t *top, unsigned int index)
 	return NULL;
 }
 
-bool
+ucl_object_t *
 ucl_array_replace_index (ucl_object_t *top, ucl_object_t *elt,
 	unsigned int index)
 {
-	ucl_object_t *dst_obj = NULL;
+	ucl_object_t *cur, *tmp;
 
-	if (top == NULL || top->type != UCL_ARRAY || elt == NULL) {
-		return false;
+	if (top == NULL || top->type != UCL_ARRAY || elt == NULL ||
+			top->len == 0 || (index + 1) > top->len) {
+		return NULL;
 	}
-	dst_obj = __DECONST(ucl_object_t *, ucl_array_find_index (top, index));
-	if (dst_obj == NULL) {
-		return false;
+
+	DL_FOREACH_SAFE (top->value.av, cur, tmp) {
+		if (index == 0) {
+			DL_REPLACE_ELEM (top->value.av, cur, elt);
+			return cur;
+		}
+		--index;
 	}
-	dst_obj->len = elt->len;
-	dst_obj->value = elt->value;
-	return true;
+
+	return NULL;
 }
 
 ucl_object_t *


### PR DESCRIPTION
Overwrite the indicated array index with a new value, keeping its position in the array
