### PR TITLE
Fix recursive iteration bug

### DIFF
--- a/utils/objdump.c
+++ b/utils/objdump.c
@@ -53,6 +53,7 @@ ucl_obj_dump (const ucl_object_t *obj, unsigned int shift)
 		if (obj->type == UCL_OBJECT) {
 			printf ("%stype: UCL_OBJECT\n", pre);
 			printf ("%svalue: %p\n", pre, obj->value.ov);
+			it_obj = NULL;
 			while ((cur = ucl_iterate_object (obj, &it_obj, true))) {
 				ucl_obj_dump (cur, shift + 2);
 			}


### PR DESCRIPTION
When iterating over a sub-object, it_obj is not reset to NULL and causes it to incorrectly display the first item twice.
