### PR TITLE
Fix bug in automatic explicit array creation code

### DIFF
--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -984,6 +984,7 @@ ucl_parser_append_elt (struct ucl_parser *parser, ucl_hash_t *cont,
 			nobj->key = top->key;
 			nobj->keylen = top->keylen;
 			nobj->flags |= UCL_OBJECT_MULTIVALUE;
+			DL_APPEND (nobj->value.av, top);
 			DL_APPEND (nobj->value.av, elt);
 			ucl_hash_insert (cont, nobj, nobj->key, nobj->keylen);
 		}


### PR DESCRIPTION
When a duplicate key is detected, and the parser is in UCL_PARSER_NO_IMPLICIT_ARRAYS mode, the resulting object only contains the second object (elt), the first object (top) is missing
