### PR TITLE
Ucl array replace index unref

### DIFF
--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -2001,7 +2001,6 @@ ucl_array_replace_index (ucl_object_t *top, ucl_object_t *elt,
 			 * freed, otherwise ucl_object_unref() will walk the
 			 * linked list and remove more items than we want
 			 */
-			cur->prev = NULL;
 			cur->next = NULL;
 			return cur;
 		}

--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -1996,6 +1996,13 @@ ucl_array_replace_index (ucl_object_t *top, ucl_object_t *elt,
 	DL_FOREACH_SAFE (top->value.av, cur, tmp) {
 		if (index == 0) {
 			DL_REPLACE_ELEM (top->value.av, cur, elt);
+			/*
+			 * Unlink cur from the linked list so it can safely be
+			 * freed, otherwise ucl_object_unref() will walk the
+			 * linked list and remove more items than we want
+			 */
+			cur->prev = NULL;
+			cur->next = NULL;
 			return cur;
 		}
 		--index;


### PR DESCRIPTION
This way when the element is ucl_object_unref()'d, it doesn't cause the items after that item in the linked-list to also be unrefd