### PR TITLE
add a version of ucl_lookup_path with an arbitrary delimiter

### DIFF
--- a/include/ucl.h
+++ b/include/ucl.h
@@ -631,6 +631,16 @@ UCL_EXTERN const ucl_object_t *ucl_lookup_path (const ucl_object_t *obj,
 		const char *path);
 
 /**
+ * Return object identified by object notation string using arbitrary delimiter
+ * @param obj object to search in
+ * @param path dot.notation.path to the path to lookup. May use numeric .index on arrays
+ * @param sep the sepatorator to use in place of . (incase keys have . in them)
+ * @return object matched the specified path or NULL if path is not found
+ */
+UCL_EXTERN const ucl_object_t *ucl_lookup_path_char (const ucl_object_t *obj,
+		const char *path, char sep);
+
+/**
  * Returns a key of an object as a NULL terminated string
  * @param obj CL object
  * @return key or NULL if there is no key

--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -1792,6 +1792,12 @@ ucl_object_iterate_free (ucl_object_iter_t it)
 
 const ucl_object_t *
 ucl_lookup_path (const ucl_object_t *top, const char *path_in) {
+	return ucl_lookup_path_char (top, path_in, '.');
+}
+
+
+const ucl_object_t *
+ucl_lookup_path_char (const ucl_object_t *top, const char *path_in, const char sep) {
 	const ucl_object_t *o = NULL, *found;
 	const char *p, *c;
 	char *err_str;
@@ -1805,20 +1811,20 @@ ucl_lookup_path (const ucl_object_t *top, const char *path_in) {
 	p = path_in;
 
 	/* Skip leading dots */
-	while (*p == '.') {
+	while (*p == sep) {
 		p ++;
 	}
 
 	c = p;
 	while (*p != '\0') {
 		p ++;
-		if (*p == '.' || *p == '\0') {
+		if (*p == sep || *p == '\0') {
 			if (p > c) {
 				switch (top->type) {
 				case UCL_ARRAY:
 					/* Key should be an int */
 					index = strtoul (c, &err_str, 10);
-					if (err_str != NULL && (*err_str != '.' && *err_str != '\0')) {
+					if (err_str != NULL && (*err_str != sep && *err_str != '\0')) {
 						return NULL;
 					}
 					o = ucl_array_find_index (top, index);


### PR DESCRIPTION
Add a new function to lookup an object by its path using an arbitrary delimiter instead of dot
Switch ucl_lookup_path to use this with dot (.) as the delimiter

This is required when key names contain dots (such as in jail.conf)

