### PR TITLE
Python extension: add 2.7 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ Makefile.in
 
 # pkgconf
 libucl.pc
+
+# python extension
+python/build

--- a/python/src/uclmodule.c
+++ b/python/src/uclmodule.c
@@ -136,6 +136,7 @@ static PyMethodDef uclMethods[] = {
 	{NULL, NULL, 0, NULL}
 };
 
+#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef uclmodule = {
 	PyModuleDef_HEAD_INIT,
 	"ucl",
@@ -148,3 +149,8 @@ PyMODINIT_FUNC
 PyInit_ucl(void) {
 	return PyModule_Create(&uclmodule);
 }
+#else
+void initucl(void) {
+	Py_InitModule("ucl", uclMethods);
+}
+#endif

--- a/python/test_uclmodule.py
+++ b/python/test_uclmodule.py
@@ -2,6 +2,11 @@
 import json
 import unittest
 import ucl
+import sys
+
+if sys.version_info[:2] == (2, 7):
+    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
+
 
 class TestUcl(unittest.TestCase):
     def test_no_args(self):


### PR DESCRIPTION
Could probably look nicer, but build and links without issues as well as passes on 2.7,3.3 and 3.4.