### PR TITLE
Fix kv_concat

### DIFF
--- a/klib/kvec.h
+++ b/klib/kvec.h
@@ -89,7 +89,7 @@ int main() {
 
 #define kv_concat(type, v1, v0) do {										\
 	if ((v1).m < (v0).n + (v1).n) kv_resize(type, v1, (v0).n + (v1).n);		\
-		memcpy((v1).a + (v1).n, (v0).a, sizeof(type) * ((v0).n + (v1).n));	\
+		memcpy((v1).a + (v1).n, (v0).a, sizeof(type) * (v0).n);	\
 		(v1).n = (v0).n + (v1).n;											\
 	} while (0)
 


### PR DESCRIPTION
memcpy was being called to append with the wrong length argument
We are copying v0.a to v1.a at offset v1.n, so length should just be sizeof(type) * v0.n, not sizeof(type) * (v0.n + v1.n)
Which is the resulting length of the entire pointer.

Resolves out-of-bounds access errors.