### PR TITLE
Restore the functionality of the copy parameter of ucl_array_merge

### DIFF
--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -2076,13 +2076,22 @@ bool
 ucl_array_merge (ucl_object_t *top, ucl_object_t *elt, bool copy)
 {
 	unsigned i;
+	ucl_object_t *cp = NULL;
 	ucl_object_t **obj;
-	UCL_ARRAY_GET (v1, top);
-	UCL_ARRAY_GET (v2, elt);
 
 	if (elt == NULL || top == NULL || top->type != UCL_ARRAY || elt->type != UCL_ARRAY) {
 		return false;
 	}
+
+	if (copy) {
+		cp = ucl_object_copy (elt);
+	}
+	else {
+		cp = ucl_object_ref (elt);
+	}
+
+	UCL_ARRAY_GET (v1, top);
+	UCL_ARRAY_GET (v2, cp);
 
 	kv_concat (ucl_object_t *, *v1, *v2);
 
@@ -2091,14 +2100,7 @@ ucl_array_merge (ucl_object_t *top, ucl_object_t *elt, bool copy)
 		if (*obj == NULL) {
 			continue;
 		}
-
 		top->len ++;
-		if (copy) {
-			*obj = ucl_object_copy (*obj);
-		}
-		else {
-			ucl_object_ref (*obj);
-		}
 	}
 
 	return true;


### PR DESCRIPTION
We should operate on a reference (or copy) of elt, rather than elt directly.

Because kv_concat memcpy()s the pointer to the ucl_object_t, when you free elt, it results in a use-after-free when you try to read the values in top.
Doing a ucl_object_ref() will result in the items not being freeing until both elt and top are destroyed.

Optionally, using ucl_object_copy when the copy parameter of ucl_array_merge is true, will result in separate pointers, so future changes to top or elt do not affect the other.