### PR TITLE
Create a new "priority" macro

### DIFF
--- a/src/ucl_internal.h
+++ b/src/ucl_internal.h
@@ -222,13 +222,21 @@ size_t ucl_unescape_json_string (char *str, size_t len);
  * Handle include macro
  * @param data include data
  * @param len length of data
+ * @param args UCL object representing arguments to the macro
  * @param ud user data
- * @param err error ptr
  * @return
  */
 bool ucl_include_handler (const unsigned char *data, size_t len,
 		const ucl_object_t *args, void* ud);
 
+/**
+ * Handle tryinclude macro
+ * @param data include data
+ * @param len length of data
+ * @param args UCL object representing arguments to the macro
+ * @param ud user data
+ * @return
+ */
 bool ucl_try_include_handler (const unsigned char *data, size_t len,
 		const ucl_object_t *args, void* ud);
 
@@ -236,11 +244,22 @@ bool ucl_try_include_handler (const unsigned char *data, size_t len,
  * Handle includes macro
  * @param data include data
  * @param len length of data
+ * @param args UCL object representing arguments to the macro
  * @param ud user data
- * @param err error ptr
  * @return
  */
 bool ucl_includes_handler (const unsigned char *data, size_t len,
+		const ucl_object_t *args, void* ud);
+
+/**
+ * Handle priority macro
+ * @param data include data
+ * @param len length of data
+ * @param args UCL object representing arguments to the macro
+ * @param ud user data
+ * @return
+ */
+bool ucl_priority_handler (const unsigned char *data, size_t len,
 		const ucl_object_t *args, void* ud);
 
 size_t ucl_strlcpy (char *dst, const char *src, size_t siz);

--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -2096,6 +2096,7 @@ ucl_parser_new (int flags)
 	ucl_parser_register_macro (new, "include", ucl_include_handler, new);
 	ucl_parser_register_macro (new, "try_include", ucl_try_include_handler, new);
 	ucl_parser_register_macro (new, "includes", ucl_includes_handler, new);
+	ucl_parser_register_macro (new, "priority", ucl_priority_handler, new);
 
 	new->flags = flags;
 

--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -1116,8 +1116,8 @@ ucl_include_common (const unsigned char *data, size_t len,
  * Handle include macro
  * @param data include data
  * @param len length of data
+ * @param args UCL object representing arguments to the macro
  * @param ud user data
- * @param err error ptr
  * @return
  */
 UCL_EXTERN bool
@@ -1133,8 +1133,8 @@ ucl_include_handler (const unsigned char *data, size_t len,
  * Handle includes macro
  * @param data include data
  * @param len length of data
+ * @param args UCL object representing arguments to the macro
  * @param ud user data
- * @param err error ptr
  * @return
  */
 UCL_EXTERN bool
@@ -1146,7 +1146,14 @@ ucl_includes_handler (const unsigned char *data, size_t len,
 	return ucl_include_common (data, len, args, parser, false, true);
 }
 
-
+/**
+ * Handle tryinclude macro
+ * @param data include data
+ * @param len length of data
+ * @param args UCL object representing arguments to the macro
+ * @param ud user data
+ * @return
+ */
 UCL_EXTERN bool
 ucl_try_include_handler (const unsigned char *data, size_t len,
 		const ucl_object_t *args, void* ud)
@@ -1154,6 +1161,64 @@ ucl_try_include_handler (const unsigned char *data, size_t len,
 	struct ucl_parser *parser = ud;
 
 	return ucl_include_common (data, len, args, parser, true, false);
+}
+
+/**
+ * Handle priority macro
+ * @param data include data
+ * @param len length of data
+ * @param args UCL object representing arguments to the macro
+ * @param ud user data
+ * @return
+ */
+UCL_EXTERN bool
+ucl_priority_handler (const unsigned char *data, size_t len,
+		const ucl_object_t *args, void* ud)
+{
+	struct ucl_parser *parser = ud;
+	unsigned priority = 255;
+	const ucl_object_t *param;
+	bool found = false;
+	char *value = NULL, *leftover = NULL;
+	ucl_object_iter_t it = NULL;
+
+	if (parser == NULL) {
+		return false;
+	}
+
+	/* Process arguments */
+	if (args != NULL && args->type == UCL_OBJECT) {
+		while ((param = ucl_iterate_object (args, &it, true)) != NULL) {
+			if (param->type == UCL_INT) {
+				if (strcmp (param->key, "priority") == 0) {
+					priority = ucl_object_toint (param);
+					found = true;
+				}
+			}
+		}
+	}
+
+	if (len > 0) {
+		value = malloc(len + 1);
+		ucl_strlcpy(value, (const char *)data, len + 1);
+		priority = strtol(value, &leftover, 10);
+		if (*leftover != '\0') {
+			ucl_create_err (&parser->err, "Invalid priority value in macro: %s",
+				value);
+			free(value);
+			return false;
+		}
+		free(value);
+		found = true;
+	}
+
+	if (found == true) {
+		parser->chunks->priority = priority;
+		return true;
+	}
+
+	ucl_create_err (&parser->err, "Unable to parse priority macro");
+	return false;
 }
 
 UCL_EXTERN bool


### PR DESCRIPTION
defines the priority of all objects defined after the macro (does not affect previous objects)

key1 = value1
.priority 5
key2 = value2
key3 = value3

key1 will have the default priority (0), and key2 and key3 will have priority 5.