### PR TITLE
fix ucl_parser_get_linenum

### DIFF
--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -529,7 +529,7 @@ ucl_parser_get_linenum(struct ucl_parser *parser)
 		return 0;
 	}
 
-	return parser->chunks->column;
+	return parser->chunks->line;
 }
 
 void


### PR DESCRIPTION
mistakenly returned the column instead of the line number