### PR TITLE
fix include globbing

### DIFF
--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -1041,7 +1041,8 @@ ucl_include_file (const unsigned char *data, size_t len,
 		if (need_glob) {
 			glob_t globbuf;
 			memset (&globbuf, 0, sizeof (globbuf));
-			ucl_strlcpy (glob_pattern, (const char *)data, sizeof (glob_pattern));
+			ucl_strlcpy (glob_pattern, (const char *)data,
+				(len + 1 < sizeof (glob_pattern) ? len + 1 : sizeof (glob_pattern)));
 			if (glob (glob_pattern, 0, NULL, &globbuf) != 0) {
 				return (!must_exist || false);
 			}


### PR DESCRIPTION
the strlcpy done to copy the user-provided glob string used the length of the destination, without consideration for the fact that the source was not null terminated. Use the lesser of the size of the destination and the length of the source (plus 1 for the terminating null character that will be added by strlcpy)