### PR TITLE
add path parameter to .include macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ parser is created but before any configurations are parsed.
 all files that matches the specified pattern (normally the format of patterns is defined in `glob` manual page
 for your operating system). This option is meaningless for URL includes.
 * `url` (default: **true**) - allow URL includes.
+* `path` (default: empty) - A UCL_ARRAY of directories to search for the include file.
+Search ends after the first patch, unless `glob` is true, then all matches are included.
 * `priority` (default: 0) - specify priority for the include (see below).
 
 Priorities are used by UCL parser to manage the policy of objects rewriting during including other files

--- a/include/ucl.h
+++ b/include/ucl.h
@@ -939,6 +939,16 @@ UCL_EXTERN bool ucl_parser_add_fd_priority (struct ucl_parser *parser,
 		int fd, unsigned priority);
 
 /**
+ * Provide a UCL_ARRAY of paths to search for include files. The object is
+ * copied so caller must unref the object.
+ * @param parser parser structure
+ * @param paths UCL_ARRAY of paths to search
+ * @return true if the path search array was replaced in the parser
+ */
+UCL_EXTERN bool ucl_set_include_path (struct ucl_parser *parser,
+		ucl_object_t *paths);
+
+/**
  * Get a top object for a parser (refcount is increased)
  * @param parser parser structure
  * @param err if *err is NULL it is set to parser error

--- a/src/ucl_internal.h
+++ b/src/ucl_internal.h
@@ -196,6 +196,7 @@ struct ucl_parser {
 	ucl_object_t *top_obj;
 	ucl_object_t *cur_obj;
 	ucl_object_t *trash_objs;
+	ucl_object_t *includepaths;
 	char *cur_file;
 	struct ucl_macro *macroes;
 	struct ucl_stack *stack;

--- a/src/ucl_internal.h
+++ b/src/ucl_internal.h
@@ -249,6 +249,8 @@ size_t ucl_strlcpy (char *dst, const char *src, size_t siz);
 size_t ucl_strlcpy_unsafe (char *dst, const char *src, size_t siz);
 size_t ucl_strlcpy_tolower (char *dst, const char *src, size_t siz);
 
+char *ucl_strnstr (const char *s, const char *find, int len);
+char *ucl_strncasestr (const char *s, const char *find, int len);
 
 #ifdef __GNUC__
 static inline void

--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -2310,11 +2310,11 @@ ucl_set_include_path (struct ucl_parser *parser, ucl_object_t *paths)
 	}
 
 	if (parser->includepaths == NULL) {
-		parser->includepaths = ucl_object_copy(paths);
+		parser->includepaths = ucl_object_copy (paths);
 	}
 	else {
 		ucl_object_unref (parser->includepaths);
-		parser->includepaths = ucl_object_copy(paths);
+		parser->includepaths = ucl_object_copy (paths);
 	}
 
 	if (parser->includepaths == NULL) {

--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -2114,6 +2114,7 @@ ucl_parser_new (int flags)
 	ucl_parser_register_macro (new, "includes", ucl_includes_handler, new);
 
 	new->flags = flags;
+	new->includepaths = NULL;
 
 	/* Initial assumption about filevars */
 	ucl_parser_set_filevars (new, NULL, false);
@@ -2299,4 +2300,26 @@ ucl_parser_add_string (struct ucl_parser *parser, const char *data,
 
 	return ucl_parser_add_string_priority (parser,
 			(const unsigned char *)data, len, parser->default_priority);
+}
+
+bool
+ucl_set_include_path (struct ucl_parser *parser, ucl_object_t *paths)
+{
+	if (parser == NULL || paths == NULL) {
+		return false;
+	}
+
+	if (parser->includepaths == NULL) {
+		parser->includepaths = ucl_object_copy(paths);
+	}
+	else {
+		ucl_object_unref (parser->includepaths);
+		parser->includepaths = ucl_object_copy(paths);
+	}
+
+	if (parser->includepaths == NULL) {
+		return false;
+	}
+
+	return true;
 }

--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -1143,7 +1143,7 @@ ucl_include_common (const unsigned char *data, size_t len,
 			}
 			else if (param->type == UCL_ARRAY) {
 				if (strcmp (param->key, "path") == 0) {
-					ucl_set_include_path(parser, param);
+					ucl_set_include_path (parser, param);
 				}
 			}
 			else if (param->type == UCL_INT) {
@@ -1155,7 +1155,7 @@ ucl_include_common (const unsigned char *data, size_t len,
 	}
 
 	if (parser->includepaths == NULL) {
-		if (allow_url && strnstr(data, "://", len) != NULL) {
+		if (allow_url && ucl_strnstr(data, "://", len) != NULL) {
 			/* Globbing is not used for URL's */
 			return ucl_include_url (data, len, parser, need_sign,
 					!try_load, priority);
@@ -1167,7 +1167,7 @@ ucl_include_common (const unsigned char *data, size_t len,
 		}
 	}
 	else {
-		if (allow_url && strnstr(data, "://", len) != NULL) {
+		if (allow_url && ucl_strnstr(data, "://", len) != NULL) {
 			/* Globbing is not used for URL's */
 			return ucl_include_url (data, len, parser, need_sign,
 					!try_load, priority);
@@ -1417,6 +1417,51 @@ ucl_strlcpy_tolower (char *dst, const char *src, size_t siz)
 	}
 
 	return (s - src);    /* count does not include NUL */
+}
+
+/*
+ * Find the first occurrence of find in s
+ */
+char *
+ucl_strnstr (const char *s, const char *find, int len)
+{
+	char c, sc;
+	int mlen;
+
+	if ((c = *find++) != 0) {
+		mlen = strlen (find);
+		do {
+			do {
+				if ((sc = *s++) == 0 || len-- == 0)
+					return (NULL);
+			} while (sc != c);
+		} while (ucl_strncmp (s, find, mlen) != 0);
+		s--;
+	}
+	return ((char *)s);
+}
+
+/*
+ * Find the first occurrence of find in s, ignore case.
+ */
+char *
+ucl_strncasestr (const char *s, const char *find, int len)
+{
+	char c, sc;
+	int mlen;
+
+	if ((c = *find++) != 0) {
+		c = tolower (c);
+		mlen = strlen (find);
+		do {
+			do {
+				if ((sc = *s++) == 0 || len-- == 0)
+					return (NULL);
+			} while (tolower (sc) != c);
+		} while (ucl_strncasecmp (s, find, mlen) != 0);
+		s--;
+	}
+	return ((char *)s);
 }
 
 ucl_object_t *

--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -1128,26 +1128,26 @@ ucl_include_common (const unsigned char *data, size_t len,
 	if (args != NULL && args->type == UCL_OBJECT) {
 		while ((param = ucl_iterate_object (args, &it, true)) != NULL) {
 			if (param->type == UCL_BOOLEAN) {
-				if (strcmp (param->key, "try") == 0) {
+				if (strncmp (param->key, "try", param->keylen) == 0) {
 					try_load = ucl_object_toboolean (param);
 				}
-				else if (strcmp (param->key, "sign") == 0) {
+				else if (strncmp (param->key, "sign", param->keylen) == 0) {
 					need_sign = ucl_object_toboolean (param);
 				}
-				else if (strcmp (param->key, "glob") == 0) {
+				else if (strncmp (param->key, "glob", param->keylen) == 0) {
 					allow_glob =  ucl_object_toboolean (param);
 				}
-				else if (strcmp (param->key, "url") == 0) {
+				else if (strncmp (param->key, "url", param->keylen) == 0) {
 					allow_url =  ucl_object_toboolean (param);
 				}
 			}
 			else if (param->type == UCL_ARRAY) {
-				if (strcmp (param->key, "path") == 0) {
-					ucl_set_include_path (parser, param);
+				if (strncmp (param->key, "path", param->keylen) == 0) {
+					ucl_set_include_path (parser, __DECONST(ucl_object_t *, param));
 				}
 			}
 			else if (param->type == UCL_INT) {
-				if (strcmp (param->key, "priority") == 0) {
+				if (strncmp (param->key, "priority", param->keylen) == 0) {
 					priority = ucl_object_toint (param);
 				}
 			}
@@ -1435,7 +1435,7 @@ ucl_strnstr (const char *s, const char *find, int len)
 				if ((sc = *s++) == 0 || len-- == 0)
 					return (NULL);
 			} while (sc != c);
-		} while (ucl_strncmp (s, find, mlen) != 0);
+		} while (strncmp (s, find, mlen) != 0);
 		s--;
 	}
 	return ((char *)s);
@@ -1458,7 +1458,7 @@ ucl_strncasestr (const char *s, const char *find, int len)
 				if ((sc = *s++) == 0 || len-- == 0)
 					return (NULL);
 			} while (tolower (sc) != c);
-		} while (ucl_strncasecmp (s, find, mlen) != 0);
+		} while (strncasecmp (s, find, mlen) != 0);
 		s--;
 	}
 	return ((char *)s);


### PR DESCRIPTION
Allow searching an array of paths for includes

include macro gains new parameter 'paths', an array of paths to search
if glob=false (default), first match is included
if glob=true all matches are included

New API method:
bool ucl_set_include_path(parser, ucl_object_array)

excepts a UCL_ARRAY of paths to search for the include filename

Usage:
ucl_object_t *obj;

obj = ucl_object_typed_new(UCL_ARRAY);
ucl_array_append(obj, ucl_object_fromstring("/etc/bhyve.d"));
ucl_array_append(obj, ucl_object_fromstring("/usr/local/etc/bhyve.d"));

ucl_set_include_path(parser, obj);
ucl_object_free(obj);
