### PR TITLE
Add new .load macro

### DIFF
--- a/src/ucl_internal.h
+++ b/src/ucl_internal.h
@@ -264,6 +264,17 @@ bool ucl_includes_handler (const unsigned char *data, size_t len,
 bool ucl_priority_handler (const unsigned char *data, size_t len,
 		const ucl_object_t *args, void* ud);
 
+/**
+ * Handle load macro
+ * @param data include data
+ * @param len length of data
+ * @param args UCL object representing arguments to the macro
+ * @param ud user data
+ * @return
+ */
+bool ucl_load_handler (const unsigned char *data, size_t len,
+		const ucl_object_t *args, void* ud);
+
 size_t ucl_strlcpy (char *dst, const char *src, size_t siz);
 size_t ucl_strlcpy_unsafe (char *dst, const char *src, size_t siz);
 size_t ucl_strlcpy_tolower (char *dst, const char *src, size_t siz);

--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -2115,6 +2115,7 @@ ucl_parser_new (int flags)
 	ucl_parser_register_macro (new, "try_include", ucl_try_include_handler, new);
 	ucl_parser_register_macro (new, "includes", ucl_includes_handler, new);
 	ucl_parser_register_macro (new, "priority", ucl_priority_handler, new);
+	ucl_parser_register_macro (new, "load", ucl_load_handler, new);
 
 	new->flags = flags;
 	new->includepaths = NULL;


### PR DESCRIPTION
takes the following arguments:
try (boolean) - do not fail if the file cannot be opened
multiline (boolean) - treat as a multiline strings. ucl automatically emits as multiline anyway if len > 80 and string contains \n
escape (boolean) - JSON escape the string
trim (boolean) - remove leading and trailing whitespace (including \n)
key (string) - (required) the key to put the contents of the file into
target (string) - "string" or "int", how to store the loaded file. Default: string

and the parameter is the filename

examples:

.load(key=motd, multiline=true, try=true) "/etc/motd"
.load(key=sshd_pid, trim=true, target=int) "/var/run/sshd.pid"