### PR TITLE
Fix constructor of ucl::Ucl::const_iterator

### DIFF
--- a/include/ucl++.h
+++ b/include/ucl++.h
@@ -120,6 +120,10 @@ public:
 			it = std::shared_ptr<void>(ucl_object_iterate_new (obj.obj.get()),
 					ucl_iter_deleter());
 			cur.reset (new Ucl(ucl_object_iterate_safe (it.get(), true)));
+			if (!*cur) {
+				it.reset ();
+				cur.reset ();
+			}
 		}
 
 		const_iterator() {}


### PR DESCRIPTION
I expect next code outputs "1", but it outputs "0".

```C++
#include <iostream>
#include "ucl++.h"

int main()
{
  std::string text = "a=[]";
  std::string err;
  auto ucl_root = ucl::Ucl::parse(text, err);
  auto a = ucl_root[std::string{"a"}];
  std::cout << (a.begin() == a.end()) << std::endl;
}
```

I think that ucl::Ucl::const_iterator's constructor needs to check own status.