### PR TITLE
Copy of ucl::Ucl::const_iterator behaves incorrectly

### DIFF
--- a/include/ucl++.h
+++ b/include/ucl++.h
@@ -123,15 +123,12 @@ public:
 		}
 
 		const_iterator() {}
-		const_iterator(const const_iterator &other) {
-			it = other.it;
-		}
+		const_iterator(const const_iterator &other) = delete;
+		const_iterator(const_iterator &&other) = default;
 		~const_iterator() {}
 
-		const_iterator& operator=(const const_iterator &other) {
-			it = other.it;
-			return *this;
-		}
+		const_iterator& operator=(const const_iterator &other) = delete;
+		const_iterator& operator=(const_iterator &&other) = default;
 
 		bool operator==(const const_iterator &other) const
 		{


### PR DESCRIPTION
I expect next code outputs "2, 2", but it outputs "2, 3".

```C++
#include <iostream>
#include "ucl++.h"

int main()
{
  std::string text = "a=[1,2,3]";
  std::string err;
  auto ucl_root = ucl::Ucl::parse(text, err);
  auto a = ucl_root[std::string{"a"}];

  auto it = a.begin();
  auto it2 = it;

  // crash
  //std::cout << it2->int_value() << std::endl;

  ++it;
  ++it2;
  std::cout << it->int_value() << ", " << it2->int_value() << std::endl;
}
```

I think copied iterators cannot behave collectly because they share ucl_object_iter_t. So const_iterator should be movable, not copyable.
