### PR TITLE
python: improve boolean handling

### DIFF
--- a/python/src/uclmodule.c
+++ b/python/src/uclmodule.c
@@ -14,8 +14,7 @@ _basic_ucl_type(ucl_object_t const * const obj) {
 		return Py_BuildValue("s", ucl_object_tostring (obj));
 	}
 	else if (obj->type == UCL_BOOLEAN) {
-		// maybe used 'p' here?
-		return Py_BuildValue("s", ucl_object_tostring_forced (obj));
+		return ucl_object_toboolean(obj) ? Py_True : Py_False;
 	}
 	else if (obj->type == UCL_TIME) {
 		return Py_BuildValue("d", ucl_object_todouble (obj));

--- a/python/test_uclmodule.py
+++ b/python/test_uclmodule.py
@@ -37,6 +37,14 @@ class TestUcl(unittest.TestCase):
     def test_float(self):
         self.assertEqual(ucl.load("a : 1.1"), {"a" : 1.1})
 
+    def test_boolean(self):
+        totest = (
+            "a : True;" \
+            "b : False"
+        )
+        correct = {"a" : True, "b" : False}
+        self.assertEqual(ucl.load(totest), correct)
+
     def test_empty_ucl(self):
         r = ucl.load("{}")
         self.assertEqual(r, {})
@@ -86,9 +94,9 @@ class TestUcl(unittest.TestCase):
                 'key7': '0xreadbeef',
                 'key8': -1e-10,
                 'key9': 1,
-                'key10': 'true',
-                'key11': 'false',
-                'key12': 'true',
+                'key10': True,
+                'key11': False,
+                'key12': True,
                 }
         self.assertEqual(ucl.load(totest), correct)
 


### PR DESCRIPTION
Improve boolean handling in Python module, using native Python's boolean types (`True` or `False`) instead of string (`"true"` or `"false"`).