### PR TITLE
c++ wrapper improvements

### DIFF
--- a/include/ucl++.h
+++ b/include/ucl++.h
@@ -264,42 +264,48 @@ public:
 		return res;
 	}
 
-	double number_value () const
+	double number_value (const double default_val = 0.0) const
 	{
-		if (obj) {
-			return ucl_object_todouble (obj.get());
+		double res;
+
+		if (ucl_object_todouble_safe(obj.get(), &res)) {
+			return res;
 		}
 
-		return 0.0;
+		return default_val;
 	}
 
-	int64_t int_value () const
+	int64_t int_value (const int64_t default_val = 0) const
 	{
-		if (obj) {
-			return ucl_object_toint (obj.get());
+		int64_t res;
+
+		if (ucl_object_toint_safe(obj.get(), &res)) {
+			return res;
 		}
 
-		return 0;
+		return default_val;
 	}
 
-	bool bool_value () const
+	bool bool_value (const bool default_val = false) const
 	{
-		if (obj) {
-			return ucl_object_toboolean (obj.get());
+		bool res;
+
+		if (ucl_object_toboolean_safe(obj.get(), &res)) {
+			return res;
 		}
 
-		return false;
+		return default_val;
 	}
 
-	const std::string string_value () const
+	const std::string string_value (const std::string& default_val = "") const
 	{
-		std::string res;
+		const char* res = nullptr;
 
-		if (obj) {
-			res.assign (ucl_object_tostring (obj.get()));
+		if (ucl_object_tostring_safe(obj.get(), &res)) {
+			return res;
 		}
 
-		return res;
+		return default_val;
 	}
 
 	const Ucl operator[] (size_t i) const

--- a/include/ucl++.h
+++ b/include/ucl++.h
@@ -26,7 +26,6 @@
 #include <string>
 #include <memory>
 #include <iostream>
-#include <strstream>
 
 #include "ucl.h"
 

--- a/include/ucl++.h
+++ b/include/ucl++.h
@@ -388,7 +388,7 @@ public:
 	bool operator> (const Ucl &rhs) const { return (rhs < *this); }
 	bool operator>= (const Ucl &rhs) const { return !(*this < rhs); }
 
-	operator bool () const
+	explicit operator bool () const
 	{
 		if (!obj || type() == UCL_NULL) {
 			return false;


### PR DESCRIPTION
I propose the following changes to the c++ wrapper:

1. Do not include `<strstream>`. It is deprecated in c++11 and not even used as far as I can tell.
2. Make the default values configurable via parameter in `*_value` methods. This really handy for parsing files where some keys are optional.
3. Make the bool conversion explicit. 

The latter prevents accidental conversions to bool and further to e.g. int. Consider the following:

`int foo = obj[std::string("key")];`

We probably just forgot to add `.int_value()`. However, the line compiles just fine. `foo` will be either 0 or 1, depending on whether `"key"` is present in `obj` or not.

Additionally, this enables us to use plain `const char*` arguments for the [] operator:

`int foo = obj["key"].int_value();`

Currently, `obj["key"]` is ambiguous because it can also be interpreted as array subscription for the string. That is because obj can be converted to int, and the [] operator is commutative for `const char*`.
