### PR TITLE
C++ interface: variable support

### DIFF
--- a/include/ucl++.h
+++ b/include/ucl++.h
@@ -222,20 +222,20 @@ public:
 		obj.reset (ucl_object_fromstring_common (value.data (), value.size (),
 				UCL_STRING_RAW));
 	}
-	Ucl(const char * value) {
+	Ucl(const char *value) {
 		obj.reset (ucl_object_fromstring_common (value, 0, UCL_STRING_RAW));
 	}
 
 	// Implicit constructor: anything with a to_json() function.
 	template <class T, class = decltype(&T::to_ucl)>
-	Ucl(const T & t) : Ucl(t.to_ucl()) {}
+	Ucl(const T &t) : Ucl(t.to_ucl()) {}
 
 	// Implicit constructor: map-like objects (std::map, std::unordered_map, etc)
 	template <class M, typename std::enable_if<
 		std::is_constructible<std::string, typename M::key_type>::value
 		&& std::is_constructible<Ucl, typename M::mapped_type>::value,
 		int>::type = 0>
-	Ucl(const M & m) {
+	Ucl(const M &m) {
 		obj.reset (ucl_object_typed_new (UCL_OBJECT));
 		auto cobj = obj.get ();
 
@@ -249,7 +249,7 @@ public:
 	template <class V, typename std::enable_if<
 		std::is_constructible<Ucl, typename V::value_type>::value,
 		int>::type = 0>
-	Ucl(const V & v) {
+	Ucl(const V &v) {
 		obj.reset (ucl_object_typed_new (UCL_ARRAY));
 		auto cobj = obj.get ();
 
@@ -388,12 +388,11 @@ public:
 
 	static Ucl parse (const char *in, std::string &err)
 	{
-		if (in) {
-			return parse (std::string(in), err);
-		} else {
+		if (!in) {
 			err = "null input";
 			return nullptr;
 		}
+		return parse (std::string (in), err);
 	}
 
 	static Ucl parse (std::istream &ifs, std::string &err)
@@ -418,6 +417,9 @@ public:
 
 	static std::vector<std::string> find_variable (const char *in)
 	{
+		if (!in) {
+			return std::vector<std::string>();
+		}
 		return find_variable (std::string (in));
 	}
 
@@ -427,11 +429,11 @@ public:
 				std::istreambuf_iterator<char>()));
 	}
 
-    Ucl& operator= (Ucl rhs)
-    {
-        obj.swap (rhs.obj);
-        return *this;
-    }
+	Ucl& operator= (Ucl rhs)
+	{
+		obj.swap (rhs.obj);
+		return *this;
+	}
 
 	bool operator== (const Ucl &rhs) const
 	{

--- a/include/ucl++.h
+++ b/include/ucl++.h
@@ -25,6 +25,7 @@
 #pragma once
 #include <string>
 #include <vector>
+#include <map>
 #include <memory>
 #include <iostream>
 
@@ -369,7 +370,15 @@ public:
 
 	static Ucl parse (const std::string &in, std::string &err)
 	{
+		return parse (in, std::map<std::string, std::string>(), err);
+	}
+
+	static Ucl parse (const std::string &in, const std::map<std::string, std::string> &vars, std::string &err)
+	{
 		auto parser = ucl_parser_new (UCL_PARSER_DEFAULT);
+
+		for (const auto & item : vars)
+			ucl_parser_register_variable (parser, item.first.c_str (), item.second.c_str ());
 
 		if (!ucl_parser_add_chunk (parser, (const unsigned char *)in.data (),
 				in.size ())) {
@@ -388,17 +397,28 @@ public:
 
 	static Ucl parse (const char *in, std::string &err)
 	{
+		return parse (in, std::map<std::string, std::string>(), err);
+	}
+
+	static Ucl parse (const char *in, const std::map<std::string, std::string> &vars, std::string &err)
+	{
 		if (!in) {
 			err = "null input";
 			return nullptr;
 		}
-		return parse (std::string (in), err);
+		return parse (std::string (in), vars, err);
 	}
 
 	static Ucl parse (std::istream &ifs, std::string &err)
 	{
 		return Ucl::parse (std::string(std::istreambuf_iterator<char>(ifs),
-				std::istreambuf_iterator<char>()), err);
+				std::istreambuf_iterator<char>()), std::map<std::string, std::string>(), err);
+	}
+
+	static Ucl parse (std::istream &ifs, const std::map<std::string, std::string> &vars, std::string &err)
+	{
+		return Ucl::parse (std::string(std::istreambuf_iterator<char>(ifs),
+				std::istreambuf_iterator<char>()), vars, err);
 	}
 
 	static std::vector<std::string> find_variable (const std::string &in)


### PR DESCRIPTION
* User-defined variable support
  - Add static member function `ucl::Ucl::find_variable(...)` as an assistant function
  - Parse with variables
    - Using key-value pairs (std::map)
    - Or, using 'strategy' class (OOP design pattern); example inherited class is attached
  - Actually, user-defined `ucl_variable_handle` function was not working properly (or, this feature was not implemented yet). I tried to fix the bug in C code, and I would be grateful if you check it.
* Replace functions which have `std::istream` param, with `parse_from_file(...)` and `find_from_file(...)`
  - I think getting input from a stream object (or file pointer) is not a good idea
    - Class interface should provide 'core' and 'minimal' functionalities only, considering encapsulation. And istream-to-string conversion is not so difficult, for users of Ucl module.
    - Those functions did not check the validity of input parameters at all. They should check it, but it could be complex job...
    - Most of all, core C interface already provides the file-reading functionality. We can use `ucl_parser_add_file` function.
    - C++ interface of Ucl was inspired by json11(https://github.com/dropbox/json11/blob/master/json11.hpp), but json11 does not support istream-input.
  - However, changing(especially, removing) of interfaces is always not desirable. I'll respect your decision and restore the functions if needed.