### PR TITLE
Fix schema validation for patternProperties with object data

### DIFF
--- a/tests/schema/patternProperties.json
+++ b/tests/schema/patternProperties.json
@@ -24,6 +24,11 @@
                 "valid": false
             },
             {
+                "description": "a single invalid match is invalid",
+                "data": {"fooooo": 2, "foo": "bar"},
+                "valid": false
+            },
+            {
                 "description": "multiple invalid matches is invalid",
                 "data": {"foo": "bar", "foooooo" : "baz"},
                 "valid": false


### PR DESCRIPTION
Evaluate all object entries on patternProperties. Inserted an inverted test for this fix. Closes #147