### PR TITLE
Macro helper functions; Changing the duplicate strategy in the C++ API

### DIFF
--- a/include/ucl.h
+++ b/include/ucl.h
@@ -921,6 +921,14 @@ UCL_EXTERN struct ucl_parser* ucl_parser_new (int flags);
 UCL_EXTERN bool ucl_parser_set_default_priority (struct ucl_parser *parser,
 		unsigned prio);
 /**
+ * Gets the default priority for the parser applied to chunks that do not
+ * specify priority explicitly
+ * @param parser parser object
+ * @return true default priority (0 .. 16), -1 for failure
+ */
+UCL_EXTERN int ucl_parser_get_default_priority (struct ucl_parser *parser);
+
+/**
  * Register new handler for a macro
  * @param parser parser object
  * @param macro macro name (without leading dot)
@@ -995,6 +1003,16 @@ UCL_EXTERN bool ucl_parser_add_chunk (struct ucl_parser *parser,
  */
 UCL_EXTERN bool ucl_parser_add_chunk_priority (struct ucl_parser *parser,
 		const unsigned char *data, size_t len, unsigned priority);
+
+/**
+ * Insert new chunk to a parser (must have previously processed data with an existing top object)
+ * @param parser parser structure
+ * @param data the pointer to the beginning of a chunk
+ * @param len the length of a chunk
+ * @return true if chunk has been added and false in case of error
+ */
+UCL_EXTERN bool ucl_parser_insert_chunk (struct ucl_parser *parser,
+		const unsigned char *data, size_t len);
 
 /**
  * Full version of ucl_add_chunk with priority and duplicate strategy
@@ -1123,6 +1141,29 @@ UCL_EXTERN bool ucl_set_include_path (struct ucl_parser *parser,
  * @return top parser object or NULL
  */
 UCL_EXTERN ucl_object_t* ucl_parser_get_object (struct ucl_parser *parser);
+
+/**
+ * Get the current stack object as stack accessor function for use in macro
+ * functions (refcount is increased)
+ * @param parser parser object
+ * @param depth depth of stack to retrieve (top is 0)
+ * @return current stack object or NULL
+ */
+UCL_EXTERN ucl_object_t* ucl_parser_get_current_stack_object (struct ucl_parser *parser, unsigned int depth);
+
+/**
+ * Peek at the character at the current chunk position
+ * @param parser parser structure
+ * @return current chunk position character
+ */
+UCL_EXTERN unsigned char ucl_parser_chunk_peek (struct ucl_parser *parser);
+
+/**
+ * Skip the character at the current chunk position
+ * @param parser parser structure
+ * @return success boolean
+ */
+UCL_EXTERN bool ucl_parser_chunk_skip (struct ucl_parser *parser);
 
 /**
  * Get the error string if parsing has been failed

--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -2506,6 +2506,16 @@ ucl_parser_set_default_priority (struct ucl_parser *parser, unsigned prio)
 	return true;
 }
 
+int
+ucl_parser_get_default_priority (struct ucl_parser *parser)
+{
+	if (parser == NULL) {
+		return -1;
+	}
+
+	return parser->default_priority;
+}
+
 void
 ucl_parser_register_macro (struct ucl_parser *parser, const char *macro,
 		ucl_macro_handler handler, void* ud)
@@ -2724,6 +2734,39 @@ ucl_parser_add_chunk (struct ucl_parser *parser, const unsigned char *data,
 }
 
 bool
+ucl_parser_insert_chunk (struct ucl_parser *parser, const unsigned char *data,
+                size_t len)
+{
+	if (parser == NULL || parser->top_obj == NULL) {
+		return false;
+	}
+
+	bool res;
+	struct ucl_chunk *chunk;
+
+	int state = parser->state;
+	parser->state = UCL_STATE_INIT;
+
+	/* Prevent inserted chunks from unintentionally closing the current object */
+	if (parser->stack != NULL && parser->stack->next != NULL) parser->stack->level = parser->stack->next->level;
+
+	res = ucl_parser_add_chunk_full (parser, data, len, parser->chunks->priority,
+					parser->chunks->strategy, parser->chunks->parse_type);
+
+	/* Remove chunk from the stack */
+	chunk = parser->chunks;
+	if (chunk != NULL) {
+		parser->chunks = chunk->next;
+		UCL_FREE (sizeof (struct ucl_chunk), chunk);
+		parser->recursion --;
+	}
+
+	parser->state = state;
+
+	return res;
+}
+
+bool
 ucl_parser_add_string_priority (struct ucl_parser *parser, const char *data,
 		size_t len, unsigned priority)
 {
@@ -2772,3 +2815,54 @@ ucl_set_include_path (struct ucl_parser *parser, ucl_object_t *paths)
 
 	return true;
 }
+
+unsigned char ucl_parser_chunk_peek (struct ucl_parser *parser)
+{
+	if (parser == NULL || parser->chunks == NULL || parser->chunks->pos == NULL || parser->chunks->end == NULL ||
+		parser->chunks->pos == parser->chunks->end) {
+		return 0;
+	}
+
+	return( *parser->chunks->pos );
+}
+
+bool ucl_parser_chunk_skip (struct ucl_parser *parser)
+{
+	if (parser == NULL || parser->chunks == NULL || parser->chunks->pos == NULL || parser->chunks->end == NULL ||
+		parser->chunks->pos == parser->chunks->end) {
+		return false;
+	}
+
+	const unsigned char *p = parser->chunks->pos;
+	ucl_chunk_skipc( parser->chunks, p );
+	if( parser->chunks->pos != NULL ) return true;
+	return false;
+}
+
+ucl_object_t* ucl_parser_get_current_stack_object (struct ucl_parser *parser, unsigned int depth)
+{
+	ucl_object_t *obj;
+
+	if (parser == NULL || parser->stack == NULL) {
+		return NULL;
+	}
+
+	struct ucl_stack *stack = parser->stack;
+	if(stack == NULL || stack->obj == NULL || ucl_object_type (stack->obj) != UCL_OBJECT)
+	{
+		return NULL;
+	}
+
+	for( unsigned int i = 0; i < depth; ++i )
+	{
+		stack = stack->next;
+		if(stack == NULL || stack->obj == NULL || ucl_object_type (stack->obj) != UCL_OBJECT)
+		{
+			return NULL;
+		}
+	}
+
+	obj = ucl_object_ref (stack->obj);
+	return obj;
+}
+


### PR DESCRIPTION
This is a combination of two separate targets of code changes. I kept the changes combined because they overlap.

Macro helper functions:

Depending on the purpose of a particular macro, there are more capabilities needed than are currently provided:

* Read access to the parser stack may be necessary for informational purposes: ucl_parser_get_current_stack_object()
* The capability to see what's next in the chunks queue: ucl_parser_chunk_peek()
* The capability to skip what's next in the chunks queue: ucl_parser_chunk_skip()
* The capability to insert into the chunks queue without changing the current chunks queue and without specifying a new filename: ucl_parser_insert_chunk()
* The capability to use macros with the C++ API: multiple Ucl::parse() additions

Changing the duplicate strategy in the C++ API:

Multiple changes to Ucl::parse() to use the extended version of ucl_parser_add_chunk_full() in order to allow for changing the duplicate strategy. This required adding ucl_parser_get_default_priority() in order to avoid accidentally changing the current default priority.