### PR TITLE
Provide inline free(3) wrapper, so it's easier to plug the code into out memory usage tracking framework.

### DIFF
--- a/src/ucl_emitter_utils.c
+++ b/src/ucl_emitter_utils.c
@@ -71,6 +71,13 @@ static const struct ucl_emitter_context ucl_standard_emitters[] = {
 	}
 };
 
+static inline void
+_ucl_emitter_free(void *p)
+{
+
+    free(p);
+}
+
 /**
  * Get standard emitter context for a specified emit_type
  * @param emit_type type of emitter
@@ -405,7 +412,7 @@ ucl_object_emit_memory_funcs (void **pmem)
 		f->ucl_emitter_append_double = ucl_utstring_append_double;
 		f->ucl_emitter_append_int = ucl_utstring_append_int;
 		f->ucl_emitter_append_len = ucl_utstring_append_len;
-		f->ucl_emitter_free_func = free;
+		f->ucl_emitter_free_func = _ucl_emitter_free;
 		utstring_new (s);
 		f->ud = s;
 		*pmem = s->d;
@@ -454,7 +461,7 @@ ucl_object_emit_fd_funcs (int fd)
 		f->ucl_emitter_append_double = ucl_fd_append_double;
 		f->ucl_emitter_append_int = ucl_fd_append_int;
 		f->ucl_emitter_append_len = ucl_fd_append_len;
-		f->ucl_emitter_free_func = free;
+		f->ucl_emitter_free_func = _ucl_emitter_free;
 		f->ud = ip;
 	}
 


### PR DESCRIPTION
We use internal memory debug code which is basically set of #defines overriding memory management functions to collect information about caller tracking memory usage as well as to do some extra sanity checks around supplied pointers. Most of the libucl code fits into that framework neatly using just a single "-include rtpp_memdeb.h" processor argument, except two places in the ucl_emitter_utils, where the free function pointer is retrieved and saved explicitly. This little patch should make ucl code more friendly in this regards and be basically no-op for anyone else.

https://github.com/sippy/rtpproxy/blob/master/src/rtpp_memdeb.h