### PR TITLE
Remove unnecessary std::move from return statement.

### DIFF
--- a/include/ucl++.h
+++ b/include/ucl++.h
@@ -683,7 +683,7 @@ public:
 
 		std::vector<std::string> result;
 		std::move (vars.begin (), vars.end (), std::back_inserter (result));
-		return std::move (result);
+		return result;
 	}
 
 	Ucl& operator= (Ucl rhs)


### PR DESCRIPTION
This is not only unnecessary but it is discouraged because
it prevents return value optimizations, and suppresses
a compiler warning that warns about that.