### PR TITLE
Fix all Clang warnings from implicit conversions.

### DIFF
--- a/src/ucl_emitter.c
+++ b/src/ucl_emitter.c
@@ -121,11 +121,11 @@ ucl_emitter_print_key (bool print_key, struct ucl_emitter_context *ctx,
 			ucl_elt_string_write_json (obj->key, obj->keylen, ctx);
 		}
 		else {
-			func->ucl_emitter_append_len (obj->key, obj->keylen, func->ud);
+			func->ucl_emitter_append_len (UC_(obj->key), obj->keylen, func->ud);
 		}
 
 		if (obj->type != UCL_OBJECT && obj->type != UCL_ARRAY) {
-			func->ucl_emitter_append_len (" = ", 3, func->ud);
+			func->ucl_emitter_append_len (UC_(" = "), 3, func->ud);
 		}
 		else {
 			func->ucl_emitter_append_character (' ', 1, func->ud);
@@ -136,27 +136,27 @@ ucl_emitter_print_key (bool print_key, struct ucl_emitter_context *ctx,
 			ucl_elt_string_write_json (obj->key, obj->keylen, ctx);
 		}
 		else if (obj->keylen > 0) {
-			func->ucl_emitter_append_len (obj->key, obj->keylen, func->ud);
+			func->ucl_emitter_append_len (UC_(obj->key), obj->keylen, func->ud);
 		}
 		else {
-			func->ucl_emitter_append_len ("null", 4, func->ud);
+			func->ucl_emitter_append_len (UC_("null"), 4, func->ud);
 		}
 
-		func->ucl_emitter_append_len (": ", 2, func->ud);
+		func->ucl_emitter_append_len (UC_(": "), 2, func->ud);
 	}
 	else {
 		if (obj->keylen > 0) {
 			ucl_elt_string_write_json (obj->key, obj->keylen, ctx);
 		}
 		else {
-			func->ucl_emitter_append_len ("null", 4, func->ud);
+			func->ucl_emitter_append_len (UC_("null"), 4, func->ud);
 		}
 
 		if (compact) {
 			func->ucl_emitter_append_character (':', 1, func->ud);
 		}
 		else {
-			func->ucl_emitter_append_len (": ", 2, func->ud);
+			func->ucl_emitter_append_len (UC_(": "), 2, func->ud);
 		}
 	}
 }
@@ -171,11 +171,11 @@ ucl_emitter_finish_object (struct ucl_emitter_context *ctx,
 		if (obj->type != UCL_OBJECT && obj->type != UCL_ARRAY) {
 			if (!is_array) {
 				/* Objects are split by ';' */
-				func->ucl_emitter_append_len (";\n", 2, func->ud);
+				func->ucl_emitter_append_len (UC_(";\n"), 2, func->ud);
 			}
 			else {
 				/* Use commas for arrays */
-				func->ucl_emitter_append_len (",\n", 2, func->ud);
+				func->ucl_emitter_append_len (UC_(",\n"), 2, func->ud);
 			}
 		}
 		else {
@@ -261,7 +261,7 @@ ucl_emitter_common_start_array (struct ucl_emitter_context *ctx,
 		func->ucl_emitter_append_character ('[', 1, func->ud);
 	}
 	else {
-		func->ucl_emitter_append_len ("[\n", 2, func->ud);
+		func->ucl_emitter_append_len (UC_("[\n"), 2, func->ud);
 	}
 
 	ctx->indent ++;
@@ -311,7 +311,7 @@ ucl_emitter_common_start_object (struct ucl_emitter_context *ctx,
 			func->ucl_emitter_append_character ('{', 1, func->ud);
 		}
 		else {
-			func->ucl_emitter_append_len ("{\n", 2, func->ud);
+			func->ucl_emitter_append_len (UC_("{\n"), 2, func->ud);
 		}
 		ctx->indent ++;
 	}
@@ -331,7 +331,7 @@ ucl_emitter_common_start_object (struct ucl_emitter_context *ctx,
 						func->ucl_emitter_append_character (',', 1, func->ud);
 					}
 					else {
-						func->ucl_emitter_append_len (",\n", 2, func->ud);
+						func->ucl_emitter_append_len (UC_(",\n"), 2, func->ud);
 					}
 				}
 				ucl_add_tabs (func, ctx->indent, compact);
@@ -371,9 +371,9 @@ ucl_emitter_common_elt (struct ucl_emitter_context *ctx,
 		}
 		else {
 			if (ctx->id == UCL_EMIT_YAML && ctx->indent == 0) {
-				func->ucl_emitter_append_len ("\n", 1, func->ud);
+				func->ucl_emitter_append_len (UC_("\n"), 1, func->ud);
 			} else {
-				func->ucl_emitter_append_len (",\n", 2, func->ud);
+				func->ucl_emitter_append_len (UC_(",\n"), 2, func->ud);
 			}
 		}
 	}
@@ -387,7 +387,7 @@ ucl_emitter_common_elt (struct ucl_emitter_context *ctx,
 		if (comment) {
 			if (!(comment->flags & UCL_OBJECT_INHERITED)) {
 				DL_FOREACH (comment, cur_comment) {
-					func->ucl_emitter_append_len (cur_comment->value.sv,
+					func->ucl_emitter_append_len (UC_(cur_comment->value.sv),
 							cur_comment->len,
 							func->ud);
 					func->ucl_emitter_append_character ('\n', 1, func->ud);
@@ -415,10 +415,10 @@ ucl_emitter_common_elt (struct ucl_emitter_context *ctx,
 		ucl_emitter_print_key (print_key, ctx, obj, compact);
 		flag = ucl_object_toboolean (obj);
 		if (flag) {
-			func->ucl_emitter_append_len ("true", 4, func->ud);
+			func->ucl_emitter_append_len (UC_("true"), 4, func->ud);
 		}
 		else {
-			func->ucl_emitter_append_len ("false", 5, func->ud);
+			func->ucl_emitter_append_len (UC_("false"), 5, func->ud);
 		}
 		ucl_emitter_finish_object (ctx, obj, compact, !print_key);
 		break;
@@ -442,7 +442,7 @@ ucl_emitter_common_elt (struct ucl_emitter_context *ctx,
 		break;
 	case UCL_NULL:
 		ucl_emitter_print_key (print_key, ctx, obj, compact);
-		func->ucl_emitter_append_len ("null", 4, func->ud);
+		func->ucl_emitter_append_len (UC_("null"), 4, func->ud);
 		ucl_emitter_finish_object (ctx, obj, compact, !print_key);
 		break;
 	case UCL_OBJECT:
@@ -469,7 +469,7 @@ ucl_emitter_common_elt (struct ucl_emitter_context *ctx,
 
 	if (comment) {
 		DL_FOREACH (comment, cur_comment) {
-			func->ucl_emitter_append_len (cur_comment->value.sv,
+			func->ucl_emitter_append_len (UC_(cur_comment->value.sv),
 					cur_comment->len,
 					func->ud);
 			func->ucl_emitter_append_character ('\n', 1, func->ud);

--- a/src/ucl_emitter_utils.c
+++ b/src/ucl_emitter_utils.c
@@ -113,39 +113,39 @@ ucl_elt_string_write_json (const char *str, size_t size,
 				UCL_CHARACTER_DENIED|
 				UCL_CHARACTER_WHITESPACE_UNSAFE))) {
 			if (len > 0) {
-				func->ucl_emitter_append_len (c, len, func->ud);
+				func->ucl_emitter_append_len (UC_(c), len, func->ud);
 			}
 			switch (*p) {
 			case '\n':
-				func->ucl_emitter_append_len ("\\n", 2, func->ud);
+				func->ucl_emitter_append_len (UC_("\\n"), 2, func->ud);
 				break;
 			case '\r':
-				func->ucl_emitter_append_len ("\\r", 2, func->ud);
+				func->ucl_emitter_append_len (UC_("\\r"), 2, func->ud);
 				break;
 			case '\b':
-				func->ucl_emitter_append_len ("\\b", 2, func->ud);
+				func->ucl_emitter_append_len (UC_("\\b"), 2, func->ud);
 				break;
 			case '\t':
-				func->ucl_emitter_append_len ("\\t", 2, func->ud);
+				func->ucl_emitter_append_len (UC_("\\t"), 2, func->ud);
 				break;
 			case '\f':
-				func->ucl_emitter_append_len ("\\f", 2, func->ud);
+				func->ucl_emitter_append_len (UC_("\\f"), 2, func->ud);
 				break;
 			case '\v':
-				func->ucl_emitter_append_len ("\\u000B", 6, func->ud);
+				func->ucl_emitter_append_len (UC_("\\u000B"), 6, func->ud);
 				break;
 			case '\\':
-				func->ucl_emitter_append_len ("\\\\", 2, func->ud);
+				func->ucl_emitter_append_len (UC_("\\\\"), 2, func->ud);
 				break;
 			case ' ':
 				func->ucl_emitter_append_character (' ', 1, func->ud);
 				break;
 			case '"':
-				func->ucl_emitter_append_len ("\\\"", 2, func->ud);
+				func->ucl_emitter_append_len (UC_("\\\""), 2, func->ud);
 				break;
 			default:
 				/* Emit unicode unknown character */
-				func->ucl_emitter_append_len ("\\uFFFD", 6, func->ud);
+				func->ucl_emitter_append_len (UC_("\\uFFFD"), 6, func->ud);
 				break;
 			}
 			len = 0;
@@ -159,7 +159,7 @@ ucl_elt_string_write_json (const char *str, size_t size,
 	}
 
 	if (len > 0) {
-		func->ucl_emitter_append_len (c, len, func->ud);
+		func->ucl_emitter_append_len (UC_(c), len, func->ud);
 	}
 
 	func->ucl_emitter_append_character ('"', 1, func->ud);
@@ -178,12 +178,12 @@ ucl_elt_string_write_squoted (const char *str, size_t size,
 	while (size) {
 		if (*p == '\'') {
 			if (len > 0) {
-				func->ucl_emitter_append_len (c, len, func->ud);
+				func->ucl_emitter_append_len (UC_(c), len, func->ud);
 			}
 
 			len = 0;
 			c = ++p;
-			func->ucl_emitter_append_len ("\\\'", 2, func->ud);
+			func->ucl_emitter_append_len (UC_("\\\'"), 2, func->ud);
 		}
 		else {
 			p ++;
@@ -193,7 +193,7 @@ ucl_elt_string_write_squoted (const char *str, size_t size,
 	}
 
 	if (len > 0) {
-		func->ucl_emitter_append_len (c, len, func->ud);
+		func->ucl_emitter_append_len (UC_(c), len, func->ud);
 	}
 
 	func->ucl_emitter_append_character ('\'', 1, func->ud);
@@ -205,9 +205,9 @@ ucl_elt_string_write_multiline (const char *str, size_t size,
 {
 	const struct ucl_emitter_functions *func = ctx->func;
 
-	func->ucl_emitter_append_len ("<<EOD\n", sizeof ("<<EOD\n") - 1, func->ud);
-	func->ucl_emitter_append_len (str, size, func->ud);
-	func->ucl_emitter_append_len ("\nEOD", sizeof ("\nEOD") - 1, func->ud);
+	func->ucl_emitter_append_len (UC_("<<EOD\n"), sizeof ("<<EOD\n") - 1, func->ud);
+	func->ucl_emitter_append_len (UC_(str), size, func->ud);
+	func->ucl_emitter_append_len (UC_("\nEOD"), sizeof ("\nEOD") - 1, func->ud);
 }
 
 /*
@@ -495,10 +495,10 @@ ucl_object_emit_single_json (const ucl_object_t *obj)
 	if (buf != NULL) {
 		switch (obj->type) {
 		case UCL_OBJECT:
-			ucl_utstring_append_len ("object", 6, buf);
+			ucl_utstring_append_len (UC_("object"), 6, buf);
 			break;
 		case UCL_ARRAY:
-			ucl_utstring_append_len ("array", 5, buf);
+			ucl_utstring_append_len (UC_("array"), 5, buf);
 			break;
 		case UCL_INT:
 			ucl_utstring_append_int (obj->value.iv, buf);
@@ -508,24 +508,24 @@ ucl_object_emit_single_json (const ucl_object_t *obj)
 			ucl_utstring_append_double (obj->value.dv, buf);
 			break;
 		case UCL_NULL:
-			ucl_utstring_append_len ("null", 4, buf);
+			ucl_utstring_append_len (UC_("null"), 4, buf);
 			break;
 		case UCL_BOOLEAN:
 			if (obj->value.iv) {
-				ucl_utstring_append_len ("true", 4, buf);
+				ucl_utstring_append_len (UC_("true"), 4, buf);
 			}
 			else {
-				ucl_utstring_append_len ("false", 5, buf);
+				ucl_utstring_append_len (UC_("false"), 5, buf);
 			}
 			break;
 		case UCL_STRING:
-			ucl_utstring_append_len (obj->value.sv, obj->len, buf);
+			ucl_utstring_append_len (UC_(obj->value.sv), obj->len, buf);
 			break;
 		case UCL_USERDATA:
-			ucl_utstring_append_len ("userdata", 8, buf);
+			ucl_utstring_append_len (UC_("userdata"), 8, buf);
 			break;
 		}
-		res = utstring_body (buf);
+		res = U_(utstring_body (buf));
 		free (buf);
 	}
 

--- a/src/ucl_internal.h
+++ b/src/ucl_internal.h
@@ -134,6 +134,11 @@ typedef SSIZE_T ssize_t;
 #define __DECONST(type, var)    ((type)(uintptr_t)(const void *)(var))
 #endif
 
+#define U_( a ) (unsigned char*)(a)
+#define UC_( a ) (const unsigned char*)(a)
+#define S_( a ) (char*)(a)
+#define SC_( a ) (const char*)(a)
+
 /**
  * @file rcl_internal.h
  * Internal structures and functions of UCL library

--- a/src/ucl_msgpack.c
+++ b/src/ucl_msgpack.c
@@ -244,7 +244,7 @@ ucl_emitter_print_string_msgpack (struct ucl_emitter_context *ctx,
 	}
 
 	func->ucl_emitter_append_len (buf, blen, func->ud);
-	func->ucl_emitter_append_len (s, len, func->ud);
+	func->ucl_emitter_append_len (UC_(s), len, func->ud);
 }
 
 void
@@ -277,7 +277,7 @@ ucl_emitter_print_binary_string_msgpack (struct ucl_emitter_context *ctx,
 	}
 
 	func->ucl_emitter_append_len (buf, blen, func->ud);
-	func->ucl_emitter_append_len (s, len, func->ud);
+	func->ucl_emitter_append_len (UC_(s), len, func->ud);
 }
 
 void
@@ -856,7 +856,7 @@ ucl_msgpack_insert_object (struct ucl_parser *parser,
 			return false;
 		}
 
-		obj->key = key;
+		obj->key = SC_(key);
 		obj->keylen = keylen;
 
 		if (!(parser->flags & UCL_PARSER_ZEROCOPY)) {
@@ -1377,7 +1377,7 @@ ucl_msgpack_parse_string (struct ucl_parser *parser,
 	}
 
 	obj = ucl_object_new_full (UCL_STRING, parser->chunks->priority);
-	obj->value.sv = pos;
+	obj->value.sv = SC_(pos);
 	obj->len = len;
 
 	if (fmt >= msgpack_bin8 && fmt <= msgpack_bin32) {

--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -149,7 +149,7 @@ start:
 			while (p < chunk->end) {
 				if (*p == '\n') {
 					if (parser->flags & UCL_PARSER_SAVE_COMMENTS) {
-						ucl_save_comment (parser, beg, p - beg);
+						ucl_save_comment (parser, SC_(beg), p - beg);
 						beg = NULL;
 					}
 
@@ -180,7 +180,7 @@ start:
 							comments_nested --;
 							if (comments_nested == 0) {
 								if (parser->flags & UCL_PARSER_SAVE_COMMENTS) {
-									ucl_save_comment (parser, beg, p - beg + 1);
+									ucl_save_comment (parser, SC_(beg), p - beg + 1);
 									beg = NULL;
 								}
 
@@ -209,7 +209,7 @@ start:
 	}
 
 	if (beg && p > beg && (parser->flags & UCL_PARSER_SAVE_COMMENTS)) {
-		ucl_save_comment (parser, beg, p - beg);
+		ucl_save_comment (parser, SC_(beg), p - beg);
 	}
 
 	return true;
@@ -343,7 +343,7 @@ ucl_check_variable_safe (struct ucl_parser *parser, const char *ptr, size_t rema
 	/* XXX: can only handle ${VAR} */
 	if (!(*found) && parser->var_handler != NULL && strict) {
 		/* Call generic handler */
-		if (parser->var_handler (ptr, remain, &dst, &dstlen, &need_free,
+		if (parser->var_handler (UC_(ptr), remain, &dst, &dstlen, &need_free,
 				parser->var_data)) {
 			*found = true;
 			if (need_free) {
@@ -461,7 +461,7 @@ ucl_expand_single_variable (struct ucl_parser *parser, const char *ptr,
 	}
 	if (!found) {
 		if (strict && parser->var_handler != NULL) {
-			if (parser->var_handler (ptr, remain, &dst, &dstlen, &need_free,
+			if (parser->var_handler (UC_(ptr), remain, &dst, &dstlen, &need_free,
 							parser->var_data)) {
 				memcpy (d, dst, dstlen);
 				ret += dstlen;
@@ -583,25 +583,25 @@ ucl_copy_or_store_ptr (struct ucl_parser *parser,
 			return false;
 		}
 		if (need_lowercase) {
-			ret = ucl_strlcpy_tolower (*dst, src, in_len + 1);
+			ret = ucl_strlcpy_tolower (S_(*dst), SC_(src), in_len + 1);
 		}
 		else {
-			ret = ucl_strlcpy_unsafe (*dst, src, in_len + 1);
+			ret = ucl_strlcpy_unsafe (S_(*dst), SC_(src), in_len + 1);
 		}
 
 		if (need_unescape) {
 			if (!unescape_squote) {
-				ret = ucl_unescape_json_string (*dst, ret);
+				ret = ucl_unescape_json_string (S_(*dst), ret);
 			}
 			else {
-				ret = ucl_unescape_squoted_string (*dst, ret);
+				ret = ucl_unescape_squoted_string (S_(*dst), ret);
 			}
 		}
 
 		if (need_expand) {
 			tmp = *dst;
 			tret = ret;
-			ret = ucl_expand_variable (parser, dst, tmp, ret);
+			ret = ucl_expand_variable (parser, dst, SC_(tmp), ret);
 			if (*dst == NULL) {
 				/* Nothing to expand */
 				*dst = tmp;
@@ -612,10 +612,10 @@ ucl_copy_or_store_ptr (struct ucl_parser *parser,
 				UCL_FREE (in_len + 1, tmp);
 			}
 		}
-		*dst_const = *dst;
+		*dst_const = SC_(*dst);
 	}
 	else {
-		*dst_const = src;
+		*dst_const = SC_(src);
 		ret = in_len;
 	}
 
@@ -992,7 +992,7 @@ ucl_lex_number (struct ucl_parser *parser,
 	const unsigned char *pos;
 	int ret;
 
-	ret = ucl_maybe_parse_number (obj, chunk->pos, chunk->end, (const char **)&pos,
+	ret = ucl_maybe_parse_number (obj, SC_(chunk->pos), SC_(chunk->end), (const char **)&pos,
 			true, false, ((parser->flags & UCL_PARSER_NO_TIME) == 0));
 
 	if (ret == 0) {
@@ -2122,7 +2122,7 @@ ucl_skip_macro_as_comment (struct ucl_parser *parser,
 
 		case macro_save:
 			if (parser->flags & UCL_PARSER_SAVE_COMMENTS) {
-				ucl_save_comment (parser, c, p - c);
+				ucl_save_comment (parser, SC_(c), p - c);
 			}
 
 			return true;
@@ -2568,7 +2568,7 @@ ucl_state_machine (struct ucl_parser *parser)
 				return false;
 			}
 			macro_len = ucl_expand_variable (parser, &macro_escaped,
-					macro_start, macro_len);
+					SC_(macro_start), macro_len);
 			parser->state = parser->prev_state;
 
 			if (macro_escaped == NULL && macro != NULL) {
@@ -3033,7 +3033,7 @@ ucl_parser_add_string (struct ucl_parser *parser, const char *data,
 	}
 
 	return ucl_parser_add_string_priority (parser,
-			(const unsigned char *)data, len, parser->default_priority);
+			SC_(data), len, parser->default_priority);
 }
 
 bool

--- a/src/ucl_schema.c
+++ b/src/ucl_schema.c
@@ -771,7 +771,7 @@ ucl_schema_resolve_ref (const ucl_object_t *root, const char *ref,
 
 		if (ext_obj == NULL) {
 			if (ucl_strnstr (p, "://", strlen (p)) != NULL) {
-				if (!ucl_fetch_url (p, &url_buf, &url_buflen, &url_err, true)) {
+				if (!ucl_fetch_url (UC_(p), &url_buf, &url_buflen, &url_err, true)) {
 
 					ucl_schema_create_error (err,
 							UCL_SCHEMA_INVALID_SCHEMA,
@@ -786,7 +786,7 @@ ucl_schema_resolve_ref (const ucl_object_t *root, const char *ref,
 				}
 			}
 			else {
-				if (!ucl_fetch_file (p, &url_buf, &url_buflen, &url_err,
+				if (!ucl_fetch_file (UC_(p), &url_buf, &url_buflen, &url_err,
 						true)) {
 					ucl_schema_create_error (err,
 							UCL_SCHEMA_INVALID_SCHEMA,


### PR DESCRIPTION
This commit will fix all remaining Clang warnings that arise
from building the core libucl library.  These warnings arise
from various kinds of conversions to and from char pointers:
{signed,`unsigned`} {`const`,non-const} `char*`.

The code uses all four of these variations and implicitly
converts between them in many places.  This generates many
warnings on clang with `-Wall`.

To fix this without introducing too much noise in the code
there are four new macros:

  Cast to:               Macro
  --------------------------------
  `char*`                  `S_(...)`
  `unsigned char*`         `U_(...)`
  `const char*`            `SC_(...)`
  `const unsigned char*`   `UC_(...)`

The idea behind this change is, instead of changing any of
the types of e.g. function parameters or variables, we continue
to do the casting, but make it explicit with these macros.