### PR TITLE
Fix ucl++ bug where iterators stop on a UCL_NULL field.

### DIFF
--- a/include/ucl++.h
+++ b/include/ucl++.h
@@ -196,7 +196,7 @@ public:
 			it = std::shared_ptr<void>(ucl_object_iterate_new (obj.obj.get()),
 				ucl_iter_deleter());
 			cur.reset (new Ucl(ucl_object_iterate_safe (it.get(), true)));
-			if (cur->type() == UCL_NULL) {
+			if (!cur->obj) {
 				it.reset ();
 				cur.reset ();
 			}
@@ -230,7 +230,7 @@ public:
 				cur.reset (new Ucl(ucl_object_iterate_safe (it.get(), true)));
 			}
 
-			if (cur && cur->type() == UCL_NULL) {
+			if (cur && !cur->obj) {
 				it.reset ();
 				cur.reset ();
 			}


### PR DESCRIPTION
When iterating through the fields of an object using ucl++
the iterators would stop upon encountering a `UCL_NULL` value.
This change will make them stop only when the ucl-C iterator
functions returns `NULL`, meaning there are no fields left to
iterate.

Fixes #195