### PR TITLE
Check for NULL inputs in ucl_object_compare()

### DIFF
--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -3649,6 +3649,13 @@ ucl_object_compare (const ucl_object_t *o1, const ucl_object_t *o2)
 	ucl_object_iter_t iter = NULL;
 	int ret = 0;
 
+    // Must check for NULL or code will segfault
+    if ((o1 == NULL) || (o2 == NULL))
+    {
+        // The only way this could be true is of both are NULL
+        return (o1 == NULL) && (o2 == NULL);
+    }
+    
 	if (o1->type != o2->type) {
 		return (o1->type) - (o2->type);
 	}


### PR DESCRIPTION
The fixes segfault which crops up in C++ when you do something like the following:

```
auto s = obj["section"]["nonexistant"];
ASSERT_TRUE(s == nullptr);
```

Otherwise UCL_NULL objects segfault in comparison.