### PR TITLE
src/ucl_util.c: add missing include

### DIFF
--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -30,6 +30,10 @@
 #include <stdarg.h>
 #include <stdio.h> /* for snprintf */
 
+#ifdef __linux__
+#include <linux/limits.h>
+#endif
+
 #ifndef _WIN32
 #include <glob.h>
 #include <sys/param.h>


### PR DESCRIPTION
Hi all,

I ran into the below when building rtpproxy master, which includes a copy of libucl. I sent a PR to sippy/libucl, but seeing that is a a fork of this repo, I send the PR to you as well.

This was compile-tested on OpenWrt master with gcc 7.4.0 and libc musl. I'm not 100% what rtpproxy uses libucl for, but the resulting rtpproxy was run-tested on a big endian mips router.

Kind regards,
Seb

When building within rtpproxy the following breakage occurs:

```
../external/libucl/src/ucl_util.c: In function 'ucl_include_url':
../external/libucl/src/ucl_util.c:914:14: error: 'PATH_MAX' undeclared (first use in this function); did you mean 'INT8_MAX'?
  char urlbuf[PATH_MAX];
              ^~~~~~~~
              INT8_MAX
../external/libucl/src/ucl_util.c:914:14: note: each undeclared identifier is reported only once for each function it appears in
../external/libucl/src/ucl_util.c: In function 'ucl_include_file_single':
../external/libucl/src/ucl_util.c:987:15: error: 'PATH_MAX' undeclared (first use in this function); did you mean 'INT8_MAX'?
  char filebuf[PATH_MAX], realbuf[PATH_MAX];
               ^~~~~~~~
               INT8_MAX
../external/libucl/src/ucl_util.c:188:22: warning: implicit declaration of function 'realpath'; did you mean 'realloc'? [-Wimplicit-function-declaration]
 #define ucl_realpath realpath
                      ^
../external/libucl/src/ucl_util.c:996:6: note: in expansion of macro 'ucl_realpath'
  if (ucl_realpath (filebuf, realbuf) == NULL) {
      ^~~~~~~~~~~~
../external/libucl/src/ucl_util.c:1059:21: warning: implicit declaration of function 'strdup'; did you mean 'strcmp'? [-Wimplicit-function-declaration]
  parser->cur_file = strdup (realbuf);
                     ^~~~~~
                     strcmp
../external/libucl/src/ucl_util.c: In function 'ucl_include_file':
../external/libucl/src/ucl_util.c:1314:20: error: 'PATH_MAX' undeclared (first use in this function); did you mean 'INT8_MAX'?
  char glob_pattern[PATH_MAX];
                    ^~~~~~~~
                    INT8_MAX
../external/libucl/src/ucl_util.c: In function 'ucl_include_common':
../external/libucl/src/ucl_util.c:1390:13: error: 'PATH_MAX' undeclared (first use in this function); did you mean 'INT8_MAX'?
  char ipath[PATH_MAX];
             ^~~~~~~~
             INT8_MAX
../external/libucl/src/ucl_util.c: In function 'ucl_parser_set_filevars':
../external/libucl/src/ucl_util.c:1833:15: error: 'PATH_MAX' undeclared (first use in this function); did you mean 'INT8_MAX'?
  char realbuf[PATH_MAX], *curdir;
               ^~~~~~~~
               INT8_MAX
../external/libucl/src/ucl_util.c: In function 'ucl_parser_add_file_full':
../external/libucl/src/ucl_util.c:1868:15: error: 'PATH_MAX' undeclared (first use in this function); did you mean 'INT8_MAX'?
  char realbuf[PATH_MAX];
               ^~~~~~~~
               INT8_MAX
../external/libucl/src/ucl_util.c: In function 'ucl_object_copy_internal':
../external/libucl/src/ucl_util.c:3459:36: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
    new->trash_stack[UCL_TRASH_KEY] =
                                    ^
../external/libucl/src/ucl_util.c:3466:38: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
    new->trash_stack[UCL_TRASH_VALUE] =
                                      ^
make[4]: *** [Makefile:615: libucl_a-ucl_util.o] Error 1
```

Fix this by including the proper header.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>