### PR TITLE
Priority Validation/Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,22 @@ as following:
 
 By default, the priority of top-level object is set to zero (lowest priority). Currently,
 you can define up to 16 priorities (from 0 to 15). Includes with bigger priorities will
-rewrite keys from the objects with lower priorities as specified by the policy.
+rewrite keys from the objects with lower priorities as specified by the policy. The priority
+of the top-level or any other object can be changed with the `.priority` macro, which has no
+options and takes the new priority:
+
+```
+# Default priority: 0.
+foo = 6
+.priority 5
+# The following will have priority 5.
+bar = 6
+baz = 7
+# The following will be included with a priority of 3, 5, and 6 respectively.
+.include(priority=3) "path.conf"
+.include(priority=5) "equivalent-path.conf"
+.include(priority=6) "highpriority-path.conf"
+```
 
 ### Variables support
 

--- a/include/ucl.h
+++ b/include/ucl.h
@@ -1634,4 +1634,7 @@ UCL_EXTERN bool ucl_object_validate_root_ext (const ucl_object_t *schema,
 #define ucl_obj_ref ucl_object_ref
 #define ucl_obj_free ucl_object_free
 
+#define UCL_PRIORITY_MIN 0
+#define UCL_PRIORITY_MAX 15
+
 #endif /* UCL_H_ */

--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -1712,8 +1712,9 @@ ucl_priority_handler (const unsigned char *data, size_t len,
 	if (len > 0) {
 		value = malloc(len + 1);
 		ucl_strlcpy(value, (const char *)data, len + 1);
-		priority = strtol(value, &leftover, 10);
-		if (*leftover != '\0') {
+		errno = 0;
+		priority = strtoul(value, &leftover, 10);
+		if (errno != 0 || *leftover != '\0' || priority > UCL_PRIORITY_MAX) {
 			ucl_create_err (&parser->err, "Invalid priority value in macro: %s",
 				value);
 			free(value);

--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -1574,6 +1574,11 @@ ucl_include_common (const unsigned char *data, size_t len,
 			else if (param->type == UCL_INT) {
 				if (strncmp (param->key, "priority", param->keylen) == 0) {
 					params.priority = ucl_object_toint (param);
+					if (params.priority > UCL_PRIORITY_MAX) {
+						ucl_create_err (&parser->err, "Invalid priority value in macro: %d",
+							params.priority);
+						return false;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
libucl documents that only priorities 0-15 are valid, but does no validation on this. In-fact, even negative values are accepted and interpreted as a large unsigned quantity.

Expose the priority range via ucl.h while we're here, because it could be of use to consumers.