### PR TITLE
Pass correct pointer to var_handler

### DIFF
--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -461,7 +461,7 @@ ucl_expand_single_variable (struct ucl_parser *parser, const char *ptr,
 	}
 	if (!found) {
 		if (strict && parser->var_handler != NULL) {
-			if (parser->var_handler (ptr, remain, &dst, &dstlen, &need_free,
+			if (parser->var_handler (p, remain, &dst, &dstlen, &need_free,
 							parser->var_data)) {
 				memcpy (d, dst, dstlen);
 				ret += dstlen;


### PR DESCRIPTION
In this case `ptr` is pointer to `$` char, and `p` is pointed to character after `${`

Closes #217