### PR TITLE
fix: ucl_expand_single_variable doesn't call free

### DIFF
--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -467,6 +467,9 @@ ucl_expand_single_variable (struct ucl_parser *parser, const char *ptr,
 				ret += dstlen;
 				d += remain;
 				found = true;
+				if (need_free) {
+					free (dst);
+				}
 			}
 		}
 


### PR DESCRIPTION
ucl_expand_single_variable doesn't free `dst` even if `need_free` set to true and that leaks memory.