### PR TITLE
fix: Incorrect pointer arithmetics in ucl_expand_single_variable

### DIFF
--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -464,8 +464,8 @@ ucl_expand_single_variable (struct ucl_parser *parser, const char *ptr,
 			if (parser->var_handler (p, remain, &dst, &dstlen, &need_free,
 							parser->var_data)) {
 				memcpy (d, dst, dstlen);
-				ret += dstlen;
-				d += remain;
+				ret += remain;
+				d += dstlen;
 				found = true;
 				if (need_free) {
 					free (dst);


### PR DESCRIPTION
This one I'm not 100% sure, but other code paths in that function are doing it this way.

As I said in previous issue, I had UclObjects holding bytes related to previous allocations. I *think* it's related to this code block. Valgrind showed read/write problems related to those pointers as well.

Hopefully this is last PR for this function.