### PR TITLE
Added fuzzer for msgpack

### DIFF
--- a/tests/fuzzers/ucl_msgpack_fuzzer.c
+++ b/tests/fuzzers/ucl_msgpack_fuzzer.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include "ucl.h"
+#include "ucl_internal.h"
+#include <ctype.h>
+
+typedef ucl_object_t* (*ucl_msgpack_test)(void);
+
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+	
+	if(size<3){
+		return 0;
+	}
+
+	struct ucl_parser *parser;
+	
+	ucl_object_t *obj = ucl_object_new_full (UCL_OBJECT, 2);
+	obj->type = UCL_OBJECT;
+
+	parser = ucl_parser_new(UCL_PARSER_KEY_LOWERCASE);
+	parser->stack = NULL;
+
+	bool res = ucl_parser_add_chunk_full(parser, (const unsigned char*)data, size, 0, UCL_DUPLICATE_APPEND, UCL_PARSE_MSGPACK);
+
+	ucl_parser_free (parser);
+	return 0;
+}


### PR DESCRIPTION
A couple of notes on this fuzzer:

1: It runs out of memory fairly quickly (about 20-30 seconds). To me it looks like everything is freed as it should be, but if that is not the case, I will appreciate any observations.

2: There are 2 assertions that make the fuzzer stop altogether. The one is line 1304:
https://github.com/vstakhov/libucl/blob/e03e0bc63bfe38ac41b67779a491988d1d6fc501/src/ucl_msgpack.c#L1301-L1306
If you see a way to not trigger it, please let me know. We could free parser->stack manually and add a return statement just above it to not stop the fuzzer. 

The second is on line 1047:
https://github.com/vstakhov/libucl/blob/e03e0bc63bfe38ac41b67779a491988d1d6fc501/src/ucl_msgpack.c#L1033-L1049
Depending on what the logic is here, it might not be able to avoid it. If you have a suggestion to not abort here, do let me know.

In either case, we don’t need to change the code in the repository. We would make a temporary fix when running the fuzzers. Nevertheless, I would like to be sure that we don’t divert from the logic of the application.

It would be great if we could find a solution, as the fuzzer does find an off-by-one in ucl_msgpack.c, and it covers a large part of the ucl_msgpack.c code. 
