### PR TITLE
lua: Return early when init fails

### DIFF
--- a/lua/lua_ucl.c
+++ b/lua/lua_ucl.c
@@ -625,6 +625,7 @@ lua_ucl_parser_init (lua_State *L)
 	parser = ucl_parser_new (flags);
 	if (parser == NULL) {
 		lua_pushnil (L);
+		return 1;
 	}
 
 	pparser = lua_newuserdata (L, sizeof (parser));


### PR DESCRIPTION
If we don't return here, extra stuff gets put on the stack unaccounted for.