### PR TITLE
fix: Changed OpenSSL check inside configure.am

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,11 +73,11 @@ AC_ARG_ENABLE([utils],
 AM_CONDITIONAL([UTILS], [test x$utils = xtrue])
 
 AS_IF([test "x$enable_signatures" = "xyes"], [
-	AC_SEARCH_LIBS([EVP_MD_CTX_create], [crypto], [
+	AC_SEARCH_LIBS([CRYPTO_new_ex_data], [crypto], [
 		AC_DEFINE(HAVE_OPENSSL, 1, [Define to 1 if you have the 'crypto' library (-lcrypto).])
 		LIBCRYPTO_LIB="-lcrypto"
 		LIBS_EXTRA="${LIBS_EXTRA} -lcrypto"
-		], [AC_MSG_ERROR([unable to find the EVP_MD_CTX_create() function])])
+		], [AC_MSG_ERROR([unable to find the CRYPTO_new_ex_data() function])])
 ])
 AC_SUBST(LIBCRYPTO_LIB)
 AC_PATH_PROG(PANDOC, pandoc, [/non/existent])


### PR DESCRIPTION
In OpenSSL 1.1.0 the `EVP_MD_CTX_create()` and `EVP_MD_CTX_destroy()`
functions were renamed to `EVP_MD_CTX_new()` and `EVP_MD_CTX_free()`.
Because a check for `EVP_MD_CTX_create()` was in place inside
configure.am, building with newer OpenSSL versions could not be done.

Checking for `EVP_MD_CTX_create` function from configure.am was
replaced with a check for `CRYPTO_new_ex_data()` function.

Because a [compatibility layer][1] was introduced in OpenSSL 1.1.0,
no code changes are necessary.

Fixes: #203

[1]: https://github.com/openssl/openssl/blob/OpenSSL_1_1_0/include/openssl/evp.h#L500-L502