### PR TITLE
make use of the undocumented flag UCL_PARSER_NO_IMPLICIT_ARRAYS, so

### DIFF
--- a/python/src/uclmodule.c
+++ b/python/src/uclmodule.c
@@ -80,7 +80,8 @@ static PyObject *
 _internal_load_ucl (char *uclstr)
 {
 	PyObject *ret;
-	struct ucl_parser *parser = ucl_parser_new (UCL_PARSER_NO_TIME);
+	struct ucl_parser *parser =
+	    ucl_parser_new (UCL_PARSER_NO_TIME|UCL_PARSER_NO_IMPLICIT_ARRAYS);
 	bool r = ucl_parser_add_string(parser, uclstr, 0);
 
 	if (r) {

--- a/python/tests/test_example.py
+++ b/python/tests/test_example.py
@@ -1,0 +1,59 @@
+from .compat import unittest
+import json
+import ucl
+
+_ucl_inp = '''
+param = value;
+section {
+    param = value;
+    param1 = value1;
+    flag = true;
+    number = 10k;
+    time = 0.2s;
+    string = "something";
+    subsection {
+        host = {
+            host = "hostname";
+            port = 900;
+        }
+        host = {
+            host = "hostname";
+            port = 901;
+        }
+    }
+}
+'''
+
+_json_res = {
+	'param': 'value',
+	'section': {
+		'param': 'value',
+		'param1': 'value1',
+		'flag': True,
+		'number': 10000,
+		'time': '0.2s',
+		'string': 'something',
+		'subsection': {
+			'host': [
+				{
+					'host': 'hostname',
+					'port': 900,
+				},
+				{
+					'host': 'hostname',
+					'port': 901,
+				}
+			]
+		}
+	}
+}
+
+class TestExample(unittest.TestCase):
+	def test_example(self):
+		# load in sample UCL
+		u = ucl.load(_ucl_inp)
+
+		# Output and read back the JSON
+		uj = json.loads(json.dumps(u))
+
+		self.assertEqual(uj, _json_res)


### PR DESCRIPTION
that multiple keys are treated as arrays, and special code doesn't
have to be added to the Python module to handle it.

Add a test case to make sure that this works.

This addresses part of issue #233 where python does not work as intended.