### PR TITLE
Fixed ucl_tool's command line argument parsing

### DIFF
--- a/utils/ucl-tool.c
+++ b/utils/ucl-tool.c
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
 
   for (i = 1; i < argc; ++i) {
     parm = argv[i];
-    val = ((i + 1) < argc) ? argv[i + 1] : NULL;
+    val = ((i + 1) < argc) ? argv[++i] : NULL;
 
     if ((strcmp(parm, "--help") == 0) || (strcmp(parm, "-h") == 0)) {
       usage(argv[0], stdout);


### PR DESCRIPTION
Sorry, my bad! I did break compatibilities yesterday. Here's the fix.

Due to not increasing counter properly, ucl tool
always failed parsing command line arguments
which resulted in always displaying usage
message.