### PR TITLE
Fixed expanding variables at runtime

### DIFF
--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -345,6 +345,7 @@ ucl_check_variable_safe (struct ucl_parser *parser, const char *ptr, size_t rema
 		/* Call generic handler */
 		if (parser->var_handler (ptr, remain, &dst, &dstlen, &need_free,
 				parser->var_data)) {
+            *out_len = dstlen;
 			*found = true;
 			if (need_free) {
 				free (dst);


### PR DESCRIPTION
Expanding variables at runtime (that have not
been registered before), for example in
"ucl_parser_set_variables_handler" function,
always expanded to an empty string though
"replace" and "replace_len" were set properly.

Example config:
{
    foo = Hello World!;
    bar = ${foo};
}

Shortened unknown variable handler code:
[...]

root = ucl_parser_get_object(parser);
var = ucl_object_lookup_path(root, path);
*replace = (unsigned char*)var->value.sv;
*replace_len = var->len;
*need_free = false;
return true;

[...]

In the above handler code "path" is "foo" but could
be any dot notation path to an already existing
object.

UCL emitter always output:
{
    foo = "Hello World!";
    bar = "";
}

Forwarding announced replaced data len from handler to
"ucl_check_variable_safe" fixed the issue.