### PR TITLE
docs: fix simple typo, tectual -> textual

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -243,7 +243,7 @@ return ret;
 
 # Emitting functions
 
-Libucl can transform UCL objects to a number of tectual formats:
+Libucl can transform UCL objects to a number of textual formats:
 
 - configuration (`UCL_EMIT_CONFIG`) - nginx like human readable configuration file where implicit arrays are transformed to the duplicate keys
 - compact json: `UCL_EMIT_JSON_COMPACT` - single line valid json without spaces


### PR DESCRIPTION
There is a small typo in doc/api.md.

Should read `textual` rather than `tectual`.

