### PR TITLE
Python changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,24 @@ commands:
             sudo npm install --global coveralls
             coveralls <coverage.info
           fi
+  python:
+    description: "Build the Python bindings"
+    steps:
+      - run: |
+          sudo apt-get -qq install --no-install-recommends python3{-minimal,-pip,-dev}
+
+          python3 -m pip install --user --upgrade pip wheel setuptools
+          python3 python/setup.py sdist bdist_wheel
+
+          for dist in dist/*; do
+            python3 -m pip install --user --install-option build_ext --install-option "--library-dirs /usr/lib/x86_64-linux-gnu/" "$dist"
+            python3 -c "import ucl"
+            # relative path tests fail if we don't cd
+            pushd python
+            python3 -m unittest discover
+            popd
+            python3 -m pip uninstall -y ucl
+          done
 
 executors:
   debian:
@@ -64,6 +82,7 @@ jobs:
       - build_cmake
       - build_autotools
       - code_coverage
+      - python
 
 workflows:
   version: 2

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,0 +1,5 @@
+include COPYING
+recursive-include include *.h
+recursive-include src *.h
+recursive-include klib *.h
+recursive-include uthash *.h

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,5 +1,8 @@
 try:
     from setuptools import setup, Extension
+    # setuptools doesn't support template param for MANIFEST.in
+    from setuptools.command.egg_info import manifest_maker
+    manifest_maker.template = 'python/MANIFEST.in'
 except ImportError:
     from distutils.core import setup, Extension
 
@@ -13,16 +16,35 @@ if sys.version < '2.7':
 
 uclmodule = Extension(
     'ucl',
-    libraries = ['ucl'],
-    sources = ['src/uclmodule.c'],
-    language = 'c'
+    libraries=['ucl', 'curl'],
+    sources=['python/src/uclmodule.c'],
+    include_dirs=['include'],
+    language='c',
 )
+
+ucl_lib = {
+    'sources': ['src/' + fn for fn in os.listdir('src') if fn.endswith('.c')],
+    'include_dirs': ['include', 'src', 'uthash', 'klib'],
+    'macros': [('CURL_FOUND', '1')],
+}
+
+# sdist setup() will pull in the *.c files automatically, but not headers
+# MANIFEST.in will include the headers for sdist only
+template = 'python/MANIFEST.in'
+
+# distutils assume setup.py is in the root of the project
+# we need to include C source from the parent so trick it
+in_ucl_root = 'setup.py' in os.listdir('python')
+if in_ucl_root:
+    os.link('python/setup.py', 'setup.py')
 
 setup(
     name = 'ucl',
     version = '0.8.1',
-    description = 'ucl parser and emmitter',
+    description = 'ucl parser and emitter',
     ext_modules = [uclmodule],
+    template=template, # no longer supported with setuptools but doesn't hurt
+    libraries = [('ucl', ucl_lib)],
     test_suite = 'tests',
     tests_require = tests_require,
     author = "Eitan Adler, Denis Volpato Martins",
@@ -41,3 +63,7 @@ setup(
         "Topic :: Software Development :: Libraries",
     ]
 )
+
+# clean up the trick after the build
+if in_ucl_root:
+    os.unlink("setup.py")

--- a/python/tests/test_load.py
+++ b/python/tests/test_load.py
@@ -71,7 +71,22 @@ class LoadTest(unittest.TestCase):
         self.assertEqual(ucl.load("{/*1*/}"), {})
 
     def test_1_in(self):
-        valid = { 'key1': 'value' }
+        valid = {
+            'key1': [
+                'value',
+                'value2',
+                'value;',
+                1.0,
+                -0xdeadbeef,
+                '0xdeadbeef.1',
+                '0xreadbeef',
+                -1e-10,
+                1,
+                True,
+                False,
+                True,
+            ]
+        }
         with open("../tests/basic/1.in", "r") as in1:
             self.assertEqual(ucl.load(in1.read()), valid)
 


### PR DESCRIPTION
Some changes to the python packaging. CI fixes base on top of #246 so that should be reviewed first.

- Fix a typo in the PyPI description
- Fix a unit test
- Both `sdist` and `bdist_wheels` should work now (`setup.py` has to be run from the project root though, rather than from the `python` dir; see CI job -- linking to curl is also a bit awkward); this allows users who don't already have libucl installed to use the Python lib easily (see #202)
- Add builds for both dist methods to CI, with the existing unit tests

Some of the tests fail for what look like they should be expected errors, not sure if the tests are wrong or the code is. CI only tests Python 3 because the packages for 2 no longer exist in Debian's testing channel, but if we only need to test stable we can add that back in even though Py2 is almost unsupported.