### PR TITLE
Updated "three" to "four" output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ bla'; # Read as valuebla
 
 ## Emitter
 
-Each UCL object can be serialized to one of the three supported formats:
+Each UCL object can be serialized to one of the four supported formats:
 
 * `JSON` - canonic json notation (with spaces indented structure);
 * `Compacted JSON` - compact json notation (without spaces or newlines);


### PR DESCRIPTION
There are four possible output formats but the README says three then lists four.