### PR TITLE
Fixing building using: pip install -e "git+..."

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -12,6 +12,8 @@ import sys
 LIB_ROOT = os.path.abspath(os.path.join(__file__, os.pardir, os.pardir))  
 if os.getcwd() != LIB_ROOT:
     os.chdir(LIB_ROOT)
+if LIB_ROOT not in sys.path:
+    sys.path.append(LIB_ROOT)
 
 tests_require = []
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -9,6 +9,10 @@ except ImportError:
 import os
 import sys
 
+LIB_ROOT = os.path.abspath(os.path.join(__file__, os.pardir, os.pardir))  
+if os.getcwd() != LIB_ROOT:
+    os.chdir(LIB_ROOT)
+
 tests_require = []
 
 if sys.version < '2.7':


### PR DESCRIPTION
Fixing minor bug enabling installing python build using pip from git with following command: 
```
pip install -e "git+https://github.com/vstakhov/libucl.git/#egg=ucl&subdirectory=python"
```