### PR TITLE
ucl_maybe_parse_number: if there is trailing content, it is not a number

### DIFF
--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -849,6 +849,10 @@ ucl_maybe_parse_number (ucl_object_t *obj,
 						dv *= ucl_lex_num_multiplier (*p, false);
 					}
 					p += 2;
+					if (end - p > 0 && !ucl_lex_is_atom_end (*p)) {
+						*pos = start;
+						return EINVAL;
+					}
 					goto set_obj;
 				}
 				else if (number_bytes || (p[1] == 'b' || p[1] == 'B')) {
@@ -859,6 +863,10 @@ ucl_maybe_parse_number (ucl_object_t *obj,
 					}
 					lv *= ucl_lex_num_multiplier (*p, true);
 					p += 2;
+					if (end - p > 0 && !ucl_lex_is_atom_end (*p)) {
+						*pos = start;
+						return EINVAL;
+					}
 					goto set_obj;
 				}
 				else if (ucl_lex_is_atom_end (p[1])) {
@@ -883,6 +891,10 @@ ucl_maybe_parse_number (ucl_object_t *obj,
 						is_time = true;
 						dv *= 60.;
 						p += 3;
+						if (end - p > 0 && !ucl_lex_is_atom_end (*p)) {
+							*pos = start;
+							return EINVAL;
+						}
 						goto set_obj;
 					}
 				}
@@ -895,6 +907,10 @@ ucl_maybe_parse_number (ucl_object_t *obj,
 					lv *= ucl_lex_num_multiplier (*p, number_bytes);
 				}
 				p ++;
+				if (end - p > 0 && !ucl_lex_is_atom_end (*p)) {
+					*pos = start;
+					return EINVAL;
+				}
 				goto set_obj;
 			}
 			break;


### PR DESCRIPTION
This prevents a string like `100GB_GPT_NTFS/100GB_GPT_NTFS.img` being
interpreted as `100GB`, and ending up with a value of `107374182400`

if you called `ucl_object_fromstring_common("100GB_GPT", 0, UCL_STRING_PARSE);`
it would match the cases for 'G' 'B' but not check `ucl_lex_is_atom_end()`
to ensure that what followed the 'B' was the end of an atom, and not more
string content.

Many of the other cases do, but this fixes the ones that do not.

Sponsored-by:	Klara Inc.