### PR TITLE
Fix memory safety issues

### DIFF
--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -1828,6 +1828,11 @@ ucl_parse_value (struct ucl_parser *parser, struct ucl_chunk *chunk)
 					while (p < chunk->end && *p >= 'A' && *p <= 'Z') {
 						p ++;
 					}
+					if(p == chunk->end) {
+						ucl_set_err (parser, UCL_ESYNTAX,
+								"unterminated multiline value", &parser->err);
+						return false;
+					}
 					if (*p =='\n') {
 						/* Set chunk positions and start multiline parsing */
 						chunk->remain -= p - c + 1;

--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -520,7 +520,7 @@ ucl_expand_variable (struct ucl_parser *parser, unsigned char **dst,
 
 	p = src;
 	while (p != end) {
-		if (*p == '$') {
+		if (*p == '$' && p + 1 != end) {
 			p = ucl_check_variable (parser, p + 1, end - p - 1, &out_len, &vars_found);
 		}
 		else {

--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -47,6 +47,9 @@ struct ucl_parser_saved_state {
  */
 #define ucl_chunk_skipc(chunk, p)    \
 do {                                 \
+	if (p == chunk->end) {       \
+		break;                   \
+	}                            \
 	if (*(p) == '\n') {          \
 		(chunk)->line ++;    \
 		(chunk)->column = 0; \

--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -395,6 +395,9 @@ ucl_check_variable (struct ucl_parser *parser, const char *ptr,
 			}
 			p ++;
 		}
+		if(p == end) {
+			(*out_len) ++;
+		}
 	}
 	else if (*ptr != '$') {
 		/* Not count escaped dollar sign */

--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -1053,13 +1053,13 @@ ucl_lex_json_string (struct ucl_parser *parser,
 		}
 		else if (c == '\\') {
 			ucl_chunk_skipc (chunk, p);
-			c = *p;
 			if (p >= chunk->end) {
 				ucl_set_err (parser, UCL_ESYNTAX, "unfinished escape character",
 						&parser->err);
 				return false;
 			}
-			else if (ucl_test_character (c, UCL_CHARACTER_ESCAPE)) {
+			c = *p;
+			if (ucl_test_character (c, UCL_CHARACTER_ESCAPE)) {
 				if (c == 'u') {
 					ucl_chunk_skipc (chunk, p);
 					for (i = 0; i < 4 && p < chunk->end; i ++) {

--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -3594,9 +3594,10 @@ ucl_object_copy_internal (const ucl_object_t *other, bool allow_array)
 
 		/* deep copy of values stored */
 		if (other->trash_stack[UCL_TRASH_KEY] != NULL) {
-			new->trash_stack[UCL_TRASH_KEY] =
-					strdup (other->trash_stack[UCL_TRASH_KEY]);
+			new->trash_stack[UCL_TRASH_KEY] = NULL;
 			if (other->key == (const char *)other->trash_stack[UCL_TRASH_KEY]) {
+				new->trash_stack[UCL_TRASH_KEY] = malloc(other->keylen);
+				memcpy(new->trash_stack[UCL_TRASH_KEY], other->trash_stack[UCL_TRASH_KEY], other->keylen);
 				new->key = new->trash_stack[UCL_TRASH_KEY];
 			}
 		}

--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -3596,8 +3596,9 @@ ucl_object_copy_internal (const ucl_object_t *other, bool allow_array)
 		if (other->trash_stack[UCL_TRASH_KEY] != NULL) {
 			new->trash_stack[UCL_TRASH_KEY] = NULL;
 			if (other->key == (const char *)other->trash_stack[UCL_TRASH_KEY]) {
-				new->trash_stack[UCL_TRASH_KEY] = malloc(other->keylen);
+				new->trash_stack[UCL_TRASH_KEY] = malloc(other->keylen + 1);
 				memcpy(new->trash_stack[UCL_TRASH_KEY], other->trash_stack[UCL_TRASH_KEY], other->keylen);
+				new->trash_stack[UCL_TRASH_KEY][other->keylen] = '\0';
 				new->key = new->trash_stack[UCL_TRASH_KEY];
 			}
 		}

--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -1919,7 +1919,7 @@ ucl_inherit_handler (const unsigned char *data, size_t len,
 
 	/* Some sanity checks */
 	if (parent == NULL || ucl_object_type (parent) != UCL_OBJECT) {
-		ucl_create_err (&parser->err, "Unable to find inherited object %*.s",
+		ucl_create_err (&parser->err, "Unable to find inherited object %.*s",
 				(int)len, data);
 		return false;
 	}

--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -2177,7 +2177,7 @@ ucl_strnstr (const char *s, const char *find, int len)
 		mlen = strlen (find);
 		do {
 			do {
-				if ((sc = *s++) == 0 || len-- == 0)
+				if ((sc = *s++) == 0 || len-- < mlen)
 					return (NULL);
 			} while (sc != c);
 		} while (strncmp (s, find, mlen) != 0);


### PR DESCRIPTION
This PR fixes some memory safety issues reported by OSS-Fuzz in `ucl_add_string_fuzzer` that were labeled as security relevant:
- [Heap-buffer-overflow in ucl_lex_json_string](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21578)
- [Heap-buffer-overflow in ucl_parse_value](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21579)
- [Heap-buffer-overflow in ucl_expand_variable](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24591)
- [Heap-buffer-overflow in utstring_printf_va](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25626)
- [Heap-buffer-overflow in ucl_strnstr](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28135)
- [Heap-buffer-overflow in utstring_printf_va](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=33041)
- [Heap-buffer-overflow in ucl_check_variable](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34755)
- [Heap-buffer-overflow in _mum_hash_aligned](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38579)
- [Heap-buffer-overflow in ucl_hash_func](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38675)

The PR also fixes a couple issues I ran into while fuzzing locally, mainly in variable expansion to avoid out-of-bounds reads and writes. Each fix is in its own commit describing the issue and the fix. I'd be happy to split the PR if that made it easier to review (or to scrap the commits if you think they are not valuable)

The fuzzer still reports out-of-bounds read when parsing values, as the `strto*` functions assume the input buffer is null terminated. The `ucl_add_string_fuzzer` does not give a null-terminated buffer, but I wasn't sure if that was a proper use of the API.

I ran `make check` and got the same failures as the main branch. If there's other way to tests my changes, I'd be happy to do that as well if you point me in the right direction.