### PR TITLE
Fix excessive escaping when using `ucl_object_fromstring()`

### DIFF
--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -3068,13 +3068,13 @@ ucl_object_type (const ucl_object_t *obj)
 ucl_object_t*
 ucl_object_fromstring (const char *str)
 {
-	return ucl_object_fromstring_common (str, 0, UCL_STRING_ESCAPE);
+	return ucl_object_fromstring_common (str, 0, UCL_STRING_RAW);
 }
 
 ucl_object_t *
 ucl_object_fromlstring (const char *str, size_t len)
 {
-	return ucl_object_fromstring_common (str, len, UCL_STRING_ESCAPE);
+	return ucl_object_fromstring_common (str, len, UCL_STRING_RAW);
 }
 
 ucl_object_t *


### PR DESCRIPTION
`UCL_STRING_ESCAPE` might be useful for something (though I'm not sure what) but it's not good default behaviour. Strings are escaped during output to meet the needs of the output format, so adding escape sequences while building the object results in things being escaped twice.