### PR TITLE
python/setup.py: Avoid build failure trying to create setup.py link if it already exists.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -41,7 +41,7 @@ template = 'python/MANIFEST.in'
 # distutils assume setup.py is in the root of the project
 # we need to include C source from the parent so trick it
 in_ucl_root = 'setup.py' in os.listdir('python')
-if in_ucl_root:
+if not os.path.isfile('setup.py') and in_ucl_root:
     os.link('python/setup.py', 'setup.py')
 
 setup(


### PR DESCRIPTION
Fixes #268 (python/setup.py: incremental build fails due to already existing setup.py link)