### PR TITLE
Use `_WIN32` instead of `_MSC_VER`

### DIFF
--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -67,7 +67,7 @@ typedef kvec_t(ucl_object_t *) ucl_array_t;
 #include <fetch.h>
 #endif
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 #include <windows.h>
 #include <io.h>
 #include <direct.h>


### PR DESCRIPTION
This macro should check that the target is Windows, not that the compiler is Microsoft Visual Studio Code, which would prevent compilation with MinGW.

There are [other instances of `_MSC_VER`](https://github.com/vstakhov/libucl/search?q=_MSC_VER&type=code) which look suspiciously wrong, but this is the only one I found strictly necessary to compile libucl with MinGW.