### PR TITLE
lua: Push string with len

### DIFF
--- a/lua/lua_ucl.c
+++ b/lua/lua_ucl.c
@@ -607,11 +607,12 @@ static int
 lua_ucl_to_string (lua_State *L, const ucl_object_t *obj, enum ucl_emitter type)
 {
 	unsigned char *result;
+	size_t len;
 
-	result = ucl_object_emit (obj, type);
+	result = ucl_object_emit_len (obj, type, &len);
 
 	if (result != NULL) {
-		lua_pushstring (L, (const char *)result);
+		lua_pushlstring (L, (const char *)result, len);
 		free (result);
 	}
 	else {


### PR DESCRIPTION
Fix emitting msgpack (which may contain nul bytes) by using the actual length emitted.