### PR TITLE
ucl_emitter: fix streamlined json export

### DIFF
--- a/src/ucl_emitter.c
+++ b/src/ucl_emitter.c
@@ -268,6 +268,20 @@ ucl_emitter_common_start_array (struct ucl_emitter_context *ctx,
 		}
 	}
 
+	if (ctx->indent > 0 && ctx->id != UCL_EMIT_CONFIG) {
+		if (compact) {
+			func->ucl_emitter_append_character (',', 1, func->ud);
+		}
+		else {
+			if (ctx->id == UCL_EMIT_YAML && ctx->indent == 0) {
+				func->ucl_emitter_append_len ("\n", 1, func->ud);
+			} else {
+				func->ucl_emitter_append_len (",\n", 2, func->ud);
+			}
+		}
+	}
+	ucl_add_tabs (func, ctx->indent, compact);
+
 	ucl_emitter_print_key (print_key, ctx, obj, compact);
 
 	if (compact) {
@@ -326,6 +340,20 @@ ucl_emitter_common_start_object (struct ucl_emitter_context *ctx,
 			}
 		}
 	}
+
+	if (ctx->indent > 0 && ctx->id != UCL_EMIT_CONFIG) {
+		if (compact) {
+			func->ucl_emitter_append_character (',', 1, func->ud);
+		}
+		else {
+			if (ctx->id == UCL_EMIT_YAML && ctx->indent == 0) {
+				func->ucl_emitter_append_len ("\n", 1, func->ud);
+			} else {
+				func->ucl_emitter_append_len (",\n", 2, func->ud);
+			}
+		}
+	}
+	ucl_add_tabs (func, ctx->indent, compact);
 
 	ucl_emitter_print_key (print_key, ctx, obj, compact);
 	/*


### PR DESCRIPTION
When starting an array or an object, if there is already a level of indentation, in the context it mean the array or object is a member of a upport object or array therefore it requires a "coma"