### PR TITLE
json: fix non streamlined json emitter

### DIFF
--- a/src/ucl_emitter.c
+++ b/src/ucl_emitter.c
@@ -474,11 +474,11 @@ ucl_emitter_common_elt (struct ucl_emitter_context *ctx,
 		ucl_emitter_finish_object (ctx, obj, compact, !print_key);
 		break;
 	case UCL_OBJECT:
-		ucl_emitter_common_start_object (ctx, obj, false, print_key, compact);
+		ucl_emitter_common_start_object (ctx, obj, true, print_key, compact);
 		ucl_emitter_common_end_object (ctx, obj, compact);
 		break;
 	case UCL_ARRAY:
-		ucl_emitter_common_start_array (ctx, obj, false, print_key, compact);
+		ucl_emitter_common_start_array (ctx, obj, true, print_key, compact);
 		ucl_emitter_common_end_array (ctx, obj, compact);
 		break;
 	case UCL_USERDATA:


### PR DESCRIPTION
When the non streamline editer is about to write an element, if uses a dedicated function which deals with indentation and decorations, so when calling start_array or start_object we call it as if it was a first level of object to avoid passing through the indentation and decoration part which has been added recently to fix streamlined emitter.