### PR TITLE
crash ucl_add_string_fuzzer.c by ensuring null-termination of strings

### DIFF
--- a/tests/fuzzers/ucl_add_string_fuzzer.c
+++ b/tests/fuzzers/ucl_add_string_fuzzer.c
@@ -8,9 +8,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	// We dont null-terminate the string and by the design
 	// of the API passing 0 as size with non null-terminated string
 	// gives undefined behavior. 	
-	if(size==0){
-		return 0;
-	}
+        if(size == 0 || data[size-1] != '\0') {
+            char *new_data = (char *)malloc(size + 1);
+            memcpy(new_data, data, size);
+            new_data[size] = '\0';
+            data = (const uint8_t *)new_data;
+            size++;
+        }
 	struct ucl_parser *parser;
        	parser = ucl_parser_new(0);
 	


### PR DESCRIPTION
issue link: https://issues.oss-fuzz.com/issues/376496309
In this PR now checks if the size is 0 or if the string is not null-terminated and appends a null-terminator which prevent crashes.