### PR TITLE
add missing type checks to ucl_array_* functions

### DIFF
--- a/src/ucl_parser.c
+++ b/src/ucl_parser.c
@@ -3165,7 +3165,7 @@ ucl_parser_add_string (struct ucl_parser *parser, const char *data,
 bool
 ucl_set_include_path (struct ucl_parser *parser, ucl_object_t *paths)
 {
-	if (parser == NULL || paths == NULL) {
+	if (parser == NULL || paths == NULL || paths->type != UCL_ARRAY) {
 		return false;
 	}
 

--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -3148,6 +3148,10 @@ ucl_object_frombool (bool bv)
 bool
 ucl_array_append (ucl_object_t *top, ucl_object_t *elt)
 {
+	if (top->type != UCL_ARRAY) {
+		return false;
+	}
+
 	UCL_ARRAY_GET (vec, top);
 
 	if (elt == NULL || top == NULL) {
@@ -3177,6 +3181,10 @@ e0:
 bool
 ucl_array_prepend (ucl_object_t *top, ucl_object_t *elt)
 {
+	if (top->type != UCL_ARRAY) {
+		return false;
+	}
+
 	UCL_ARRAY_GET (vec, top);
 
 	if (elt == NULL || top == NULL) {
@@ -3242,6 +3250,10 @@ e0:
 ucl_object_t *
 ucl_array_delete (ucl_object_t *top, ucl_object_t *elt)
 {
+	if (top->type != UCL_ARRAY) {
+		return NULL;
+	}
+
 	UCL_ARRAY_GET (vec, top);
 	ucl_object_t *ret = NULL;
 	unsigned i;
@@ -3290,6 +3302,10 @@ ucl_array_tail (const ucl_object_t *top)
 ucl_object_t *
 ucl_array_pop_last (ucl_object_t *top)
 {
+	if (top->type != UCL_ARRAY) {
+		return NULL;
+	}
+
 	UCL_ARRAY_GET (vec, top);
 	ucl_object_t **obj, *ret = NULL;
 
@@ -3306,6 +3322,10 @@ ucl_array_pop_last (ucl_object_t *top)
 ucl_object_t *
 ucl_array_pop_first (ucl_object_t *top)
 {
+	if (top->type != UCL_ARRAY) {
+		return NULL;
+	}
+
 	UCL_ARRAY_GET (vec, top);
 	ucl_object_t **obj, *ret = NULL;
 
@@ -3338,6 +3358,10 @@ ucl_array_size (const ucl_object_t *top)
 const ucl_object_t *
 ucl_array_find_index (const ucl_object_t *top, unsigned int index)
 {
+	if (top->type != UCL_ARRAY) {
+		return NULL;
+	}
+
 	UCL_ARRAY_GET (vec, top);
 
 	if (vec != NULL && vec->n > 0 && index < vec->n) {
@@ -3350,6 +3374,10 @@ ucl_array_find_index (const ucl_object_t *top, unsigned int index)
 unsigned int
 ucl_array_index_of (ucl_object_t *top, ucl_object_t *elt)
 {
+	if (top->type != UCL_ARRAY) {
+		return NULL;
+	}
+
 	UCL_ARRAY_GET (vec, top);
 	unsigned i;
 
@@ -3370,6 +3398,10 @@ ucl_object_t *
 ucl_array_replace_index (ucl_object_t *top, ucl_object_t *elt,
 	unsigned int index)
 {
+	if (top->type != UCL_ARRAY) {
+		return NULL;
+	}
+
 	UCL_ARRAY_GET (vec, top);
 	ucl_object_t *ret = NULL;
 

--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -3375,7 +3375,7 @@ unsigned int
 ucl_array_index_of (ucl_object_t *top, ucl_object_t *elt)
 {
 	if (top->type != UCL_ARRAY) {
-		return NULL;
+		return (unsigned int)(-1);
 	}
 
 	UCL_ARRAY_GET (vec, top);


### PR DESCRIPTION
Hi @vstakhov,

While fuzzing we triggered crashes when array functions were called with different types. 
Adding type checks (similar to what `ucl_array_size` has) to all array functions that are missing it.