### PR TITLE
C++ API: Add a ucl::Ucl::forced_string_value method

### DIFF
--- a/include/ucl++.h
+++ b/include/ucl++.h
@@ -396,6 +396,11 @@ public:
 		return default_val;
 	}
 
+	std::string forced_string_value () const
+	{
+		return ucl_object_tostring_forced(obj.get());
+	}
+
 	size_t size () const
 	{
 		if (type () == UCL_ARRAY) {


### PR DESCRIPTION
This is a wrapper around ucl_object_tostring_forced.