### PR TITLE
json: don't add formatting for repeated blocks

### DIFF
--- a/src/ucl_emitter.c
+++ b/src/ucl_emitter.c
@@ -256,17 +256,9 @@ ucl_emitter_common_start_array (struct ucl_emitter_context *ctx,
 	bool first_key = true;
 
 	if (ctx->id != UCL_EMIT_CONFIG && !first) {
-		if (compact) {
-			func->ucl_emitter_append_character (',', 1, func->ud);
+		if (ctx->id == UCL_EMIT_YAML && ctx->indent == 0) {
+			func->ucl_emitter_append_len ("\n", 1, func->ud);
 		}
-		else {
-			if (ctx->id == UCL_EMIT_YAML && ctx->indent == 0) {
-				func->ucl_emitter_append_len ("\n", 1, func->ud);
-			} else {
-				func->ucl_emitter_append_len (",\n", 2, func->ud);
-			}
-		}
-		ucl_add_tabs (func, ctx->indent, compact);
 	}
 
 	ucl_emitter_print_key (print_key, ctx, obj, compact);


### PR DESCRIPTION
When emitting json, if there were two or more repeated sections, such
as:

  section_a { key_1 = "value_1"; }
  section_a { key_2 = "value_2"; }
  section_b { key_3 = "value_3"; }

The emitter would get confused, and assume the new section (section_b)
is part of the same config, and emit extraneous delimiters.

Instead, let the finidh object function determine when these delimiters
should be used.

Fixes #312
