### PR TITLE
Fix NULL pointer deref and memory leak in CSEXP parser

### DIFF
--- a/src/ucl_sexp.c
+++ b/src/ucl_sexp.c
@@ -178,6 +178,13 @@ bool ucl_parse_csexp(struct ucl_parser *parser)
 				ucl_copy_value_trash(obj);
 			}
 
+			if (parser->stack == NULL) {
+				ucl_object_unref(obj);
+				ucl_create_err(&parser->err, "value outside of any list");
+				state = parse_err;
+				continue;
+			}
+
 			ucl_array_append(parser->stack->obj, obj);
 			p += len;
 			NEXT_STATE;
@@ -216,12 +223,32 @@ bool ucl_parse_csexp(struct ucl_parser *parser)
 
 		case parse_err:
 		default:
+			/* Clean up orphaned stack objects that were never appended
+			 * to the tree. The outermost frame's obj == parser->top_obj
+			 * and will be freed by ucl_parser_free; all others are
+			 * orphaned and must be explicitly released here. */
+			while (parser->stack != NULL) {
+				struct ucl_stack *st_err = parser->stack;
+				parser->stack = st_err->next;
+				if (st_err->obj != NULL && st_err->obj != parser->top_obj) {
+					ucl_object_unref(st_err->obj);
+				}
+				free(st_err);
+			}
 			return false;
 		}
 	}
 
 	if (state != read_ebrace) {
 		ucl_create_err(&parser->err, "invalid finishing state: %d", state);
+		while (parser->stack != NULL) {
+			struct ucl_stack *st_err = parser->stack;
+			parser->stack = st_err->next;
+			if (st_err->obj != NULL && st_err->obj != parser->top_obj) {
+				ucl_object_unref(st_err->obj);
+			}
+			free(st_err);
+		}
 		return false;
 	}
 


### PR DESCRIPTION
Fix https://github.com/vstakhov/libucl/issues/365, including two coupled bugs in ucl_parse_csexp:

1. NULL pointer dereference in read_value (line 181): after closing the outermost list with ')', parser->stack becomes NULL.  If trailing data follows (e.g. input "()3:abc"), the parser reaches read_value and dereferences parser->stack->obj without a NULL check. Minimal trigger: ()3:abc — found via libFuzzer + ASan.

2. Memory leak on error paths: ucl_parser_free frees stack frame structs but not the ucl_object_t they hold.  In the CSEXP parser, stack objects are only appended to their parent on ')'.  If parsing fails with unclosed lists, inner stack objects are never appended to the tree and are permanently leaked. Minimal trigger: (( — confirmed via macOS leaks tool: 18 leaks / 1152 bytes before fix, 0 after.

These are coupled because fix_1 sends execution to the parse_err state, and fix_2 is the cleanup logic that runs there.
