### PR TITLE
Fix incorrect msgpack negative fixint decoding

### DIFF
--- a/src/ucl_msgpack.c
+++ b/src/ucl_msgpack.c
@@ -149,9 +149,9 @@ void ucl_emitter_print_int_msgpack(struct ucl_emitter_context *ctx, int64_t val)
 		/* Bithack abs */
 		uval = ((val ^ (val >> 63)) - (val >> 63));
 
-		if (val > -(1 << 5)) {
+		if (val >= -32) {
 			len = 1;
-			buf[0] = (mask_negative | uval) & 0xff;
+			buf[0] = (uint8_t)(int8_t)val;
 		}
 		else if (uval <= INT8_MAX) {
 			uint8_t v = (uint8_t) val;
@@ -1386,7 +1386,7 @@ ucl_msgpack_parse_int(struct ucl_parser *parser,
 		len = 1;
 		break;
 	case msgpack_negative_fixint:
-		obj->value.iv = -(*pos & 0x1f);
+		obj->value.iv = (int8_t)*pos;
 		len = 1;
 		break;
 	case msgpack_uint8:


### PR DESCRIPTION
Fix https://github.com/vstakhov/libucl/issues/368:

The mask -(*pos & 0x1f) produces wrong values for all negative fixints. For example 0xff gives -31 instead of -1, and 0xe0 gives 0 instead of -32. The msgpack spec defines negative fixint as a signed 8-bit value in bytes 0xe0-0xff, so the correct decoding is simply (int8_t)*pos.