### PR TITLE
Fix NULL pointer dereference in ucl_schema_validate

### DIFF
--- a/src/ucl_schema.c
+++ b/src/ucl_schema.c
@@ -991,7 +991,9 @@ ucl_schema_validate(const ucl_object_t *schema,
 		}
 		else {
 			/* Reset error */
-			err->code = UCL_SCHEMA_OK;
+			if (err != NULL) {
+				err->code = UCL_SCHEMA_OK;
+			}
 		}
 	}
 
@@ -1020,7 +1022,9 @@ ucl_schema_validate(const ucl_object_t *schema,
 		}
 		else {
 			/* Reset error */
-			err->code = UCL_SCHEMA_OK;
+			if (err != NULL) {
+				err->code = UCL_SCHEMA_OK;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix https://github.com/vstakhov/libucl/issues/369:

ucl_object_validate() accepts NULL for the err parameter, but ucl_schema_validate() writes to err->code without a NULL check at two locations (after anyOf and not succeed). The rest of the file uses ucl_schema_create_error() which does guard against NULL. Add the missing guards.