### PR TITLE
Fix unaligned memory access in msgpack length parsing

### DIFF
--- a/src/ucl_msgpack.c
+++ b/src/ucl_msgpack.c
@@ -960,15 +960,24 @@ ucl_msgpack_consume(struct ucl_parser *parser)
 				case 1:
 					len = *p;
 					break;
-				case 2:
-					len = FROM_BE16(*(uint16_t *) p);
+				case 2: {
+					uint16_t tmp;
+					memcpy(&tmp, p, sizeof(tmp));
+					len = FROM_BE16(tmp);
 					break;
-				case 4:
-					len = FROM_BE32(*(uint32_t *) p);
+				}
+				case 4: {
+					uint32_t tmp;
+					memcpy(&tmp, p, sizeof(tmp));
+					len = FROM_BE32(tmp);
 					break;
-				case 8:
-					len = FROM_BE64(*(uint64_t *) p);
+				}
+				case 8: {
+					uint64_t tmp;
+					memcpy(&tmp, p, sizeof(tmp));
+					len = FROM_BE64(tmp);
 					break;
+				}
 				default:
 					ucl_create_err(&parser->err, "invalid length of the length field: %u",
 								   (unsigned) obj_parser->len);


### PR DESCRIPTION
Fix https://github.com/vstakhov/libucl/issues/374:

The length field decoding in ucl_msgpack_consume() casts a byte pointer to uint16_t*/uint32_t*/uint64_t* for reading multi-byte length fields. Since msgpack is a byte-packed format, the pointer has no alignment guarantee and the cast produces undefined behavior (SIGBUS on ARM).

Use memcpy into a local variable before byte-swapping, which is the same pattern already used by the int/float parsers later in the file.