### PR TITLE
Add nesting depth limit to msgpack and CSEXP parsers

### DIFF
--- a/src/ucl_internal.h
+++ b/src/ucl_internal.h
@@ -141,6 +141,7 @@ typedef SSIZE_T ssize_t;
  */
 
 #define UCL_MAX_RECURSION 16
+#define UCL_MAX_NESTING 1024
 #define UCL_TRASH_KEY 0
 #define UCL_TRASH_VALUE 1
 

--- a/src/ucl_msgpack.c
+++ b/src/ucl_msgpack.c
@@ -693,6 +693,18 @@ ucl_msgpack_get_container(struct ucl_parser *parser,
 		/*
 		 * Insert new container to the stack
 		 */
+		unsigned int depth = 0;
+		struct ucl_stack *sp;
+		for (sp = parser->stack; sp != NULL; sp = sp->next) {
+			depth++;
+		}
+		if (depth >= UCL_MAX_NESTING) {
+			ucl_create_err(&parser->err,
+						   "msgpack containers are nested too deep (over %d)",
+						   UCL_MAX_NESTING);
+			return NULL;
+		}
+
 		if (parser->stack == NULL) {
 			parser->stack = calloc(1, sizeof(struct ucl_stack));
 

--- a/src/ucl_sexp.c
+++ b/src/ucl_sexp.c
@@ -62,6 +62,7 @@ bool ucl_parse_csexp(struct ucl_parser *parser)
 	ucl_object_t *obj;
 	struct ucl_stack *st;
 	uint64_t len = 0;
+	unsigned int depth = 0;
 	enum {
 		start_parse,
 		read_obrace,
@@ -95,6 +96,14 @@ bool ucl_parse_csexp(struct ucl_parser *parser)
 			break;
 
 		case read_obrace:
+			if (depth >= UCL_MAX_NESTING) {
+				ucl_create_err(&parser->err,
+							   "csexp nesting too deep (over %d)",
+							   UCL_MAX_NESTING);
+				state = parse_err;
+				continue;
+			}
+
 			st = calloc(1, sizeof(*st));
 
 			if (st == NULL) {
@@ -125,6 +134,7 @@ bool ucl_parse_csexp(struct ucl_parser *parser)
 				LL_PREPEND(parser->stack, st);
 			}
 
+			depth++;
 			p++;
 			NEXT_STATE;
 
@@ -217,6 +227,9 @@ bool ucl_parse_csexp(struct ucl_parser *parser)
 
 			free(st);
 			st = NULL;
+			if (depth > 0) {
+				depth--;
+			}
 			p++;
 			NEXT_STATE;
 			break;


### PR DESCRIPTION
Fix https://github.com/vstakhov/libucl/issues/376: The UCL text parser enforces a nesting depth limit, but the msgpack and CSEXP parsers had none. Deeply nested input could allocate heap memory without bound.

Add a UCL_MAX_NESTING limit (1024) to both parsers, matching the pattern used by the UCL text parser. Also count depth in the CSEXP parser's read_obrace/read_ebrace states.