### PR TITLE
Fix pointer return in ucl_object_pop_keyl()

### DIFF
--- a/src/ucl_util.c
+++ b/src/ucl_util.c
@@ -2509,7 +2509,7 @@ ucl_object_pop_keyl(ucl_object_t *top, const char *key, size_t keylen)
 	const ucl_object_t *found;
 
 	if (top == NULL || key == NULL) {
-		return false;
+		return NULL;
 	}
 	found = ucl_object_lookup_len(top, key, keylen);
 


### PR DESCRIPTION
`ucl_object_pop_keyl()` returns `ucl_object_t *`, but its invalid-input path returned `false` instead of `NULL`.

Older C modes often accept this implicitly, but newer modes such as C23 might warn on the boolean-to-pointer conversion. Return `NULL` here to match the function's declared type, improve standard conformance, and keep the code building cleanly across both older and newer language modes.