### PR TITLE
OSS-Fuzz: Fix blocking for msgpack fuzzer

### DIFF
--- a/tests/fuzzers/ucl_msgpack_fuzzer.c
+++ b/tests/fuzzers/ucl_msgpack_fuzzer.c
@@ -2,28 +2,25 @@
 #include <errno.h>
 #include <unistd.h>
 #include "ucl.h"
-#include "ucl_internal.h"
-#include <ctype.h>
-
-typedef ucl_object_t* (*ucl_msgpack_test)(void);
-
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	
-	if(size<3){
+	if (size < 3) {
 		return 0;
 	}
 
-	struct ucl_parser *parser;
-	
-	ucl_object_t *obj = ucl_object_new_full (UCL_OBJECT, 2);
-	obj->type = UCL_OBJECT;
+	struct ucl_parser *parser = ucl_parser_new(UCL_PARSER_KEY_LOWERCASE);
+	if (parser == NULL) {
+		return 0;
+	}
 
-	parser = ucl_parser_new(UCL_PARSER_KEY_LOWERCASE);
-	parser->stack = NULL;
+	if (ucl_parser_add_chunk_full(parser, (const unsigned char *)data, size,
+			0, UCL_DUPLICATE_APPEND, UCL_PARSE_MSGPACK)) {
+		ucl_object_t *obj = ucl_parser_get_object(parser);
+		if (obj != NULL) {
+			ucl_object_unref(obj);
+		}
+	}
 
-	bool res = ucl_parser_add_chunk_full(parser, (const unsigned char*)data, size, 0, UCL_DUPLICATE_APPEND, UCL_PARSE_MSGPACK);
-
-	ucl_parser_free (parser);
+	ucl_parser_free(parser);
 	return 0;
 }


### PR DESCRIPTION
This PR fixes the buggy ucl_msgpack_fuzzer and unblock its fuzzing coverage, together with the fixes in OSS-Fuzz (https://github.com/google/oss-fuzz/pull/15775) to enable the fuzzing for msgpack processing.